### PR TITLE
Add workflow & version docs; bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@
 | [后端 API](docs/BACKEND_API.md) | REST API 规范与重点接口 |
 | [API Key 外部接入](docs/API_KEY_API.md) | 外部系统调用说明 |
 | [安全加固](docs/SECURITY.md) | 生产安全检查清单 |
+| [版本更新与规划](docs/VERSION_HISTORY.md) | 当前版本、功能地图与后续规划 |
+| [开发者流程](docs/DEVELOPER_WORKFLOW.md) | 分支、验证、合并与发布流程 |
 
 服务启动后可访问 `/api/v1/docs` 查看 Swagger UI。
 

--- a/docs/DEVELOPER_WORKFLOW.md
+++ b/docs/DEVELOPER_WORKFLOW.md
@@ -1,0 +1,160 @@
+# 开发者开发流程
+
+本文档规定 Twilight 的日常开发、验证、Git 分支和发布流程。默认协作模式：开发在 `dev` 分支完成，仓库维护者手动 push 并合并到 `main`。
+
+## 分支规则
+
+| 分支 | 用途 | 权限 |
+| ---- | ---- | ---- |
+| `main` | 稳定分支，面向部署和发布。 | 只允许维护者合并。 |
+| `dev` | 日常开发集成分支。 | 开发者在此提交变更。 |
+| `feature/*` | 可选，复杂功能拆分开发。 | 完成后合并回 `dev`。 |
+| `hotfix/*` | 可选，紧急修复。 | 修复后同时回合 `main` 与 `dev`。 |
+
+当前工作流要求：不要直接 push 到 `main`。开发者完成工作后告知维护者，由维护者手动检查、push、合并。
+
+## 首次准备
+
+```bash
+git fetch origin
+git switch main
+git pull --ff-only origin main
+git switch -c dev
+```
+
+如果 `dev` 已存在：
+
+```bash
+git fetch origin
+git switch dev
+git merge --ff-only origin/main
+```
+
+## 日常开发流程
+
+1. 确认当前分支：`git status --short --branch`。
+2. 确认在 `dev` 分支：`git switch dev`。
+3. 开发前拉取最新 `main`：`git fetch origin` 后由维护者或开发者确认是否需要合并。
+4. 修改代码时遵循最小正确改动，避免无关重构。
+5. 涉及接口、配置、安全、部署、前端行为时同步更新 `docs/`。
+6. 涉及版本发布时更新 `docs/VERSION_HISTORY.md` 和版本号文件。
+7. 本地运行验证命令。
+8. 检查 diff，确认没有密钥、数据库、上传文件或本地配置误提交。
+9. 通知维护者检查并执行 push/合并。
+
+## 推荐验证命令
+
+后端语法检查：
+
+```bash
+python -m py_compile main.py asgi.py
+```
+
+修改指定后端文件时可补充：
+
+```bash
+python -m py_compile src/api/v1/users.py src/api/v1/admin.py src/services/user_service.py
+```
+
+前端 lint：
+
+```bash
+cd webui
+npm run lint
+```
+
+如项目后续补齐测试目录，优先运行：
+
+```bash
+pytest
+```
+
+## 修改 API 的规则
+
+- 新增接口必须登记到 `docs/API_INDEX.md`。
+- 需要请求体、响应体、安全说明、限流说明的接口必须更新 `docs/BACKEND_API.md`。
+- API Key 专用接口必须更新 `docs/API_KEY_API.md`。
+- 公开接口必须明确限流和信息泄露风险。
+- 管理接口默认必须有登录鉴权和管理员鉴权。
+
+## 修改配置的规则
+
+配置项必须同时更新：
+
+1. `src/config.py` 中的配置类默认值。
+2. `src/api/v1/system.py` 的配置 schema。
+3. `config.toml` 和 `config.production.toml` 示例。
+4. 需要迁移旧字段时，在配置 sweep 迁移规则里登记。
+5. 需要固定枚举时，前端使用单选，后端保存接口校验预设值。
+
+## 修改前端的规则
+
+- 优先复用 `webui/src/components/ui/` 的基础组件。
+- 保持现有布局和视觉语言，不新增无关 UI 框架。
+- API 调用集中放在 `webui/src/lib/api.ts`。
+- 涉及认证态、系统配置、区域刷新时复用已有 store/hook。
+- 新页面必须考虑桌面和移动端基本可用。
+
+## 修改数据库的规则
+
+- 现有数据库按模块拆分在 `src/db/*.py`。
+- 新增字段要考虑旧数据默认值、空值、迁移和文档。
+- 不要把 sqlite 数据库文件提交到仓库。
+- 新增 `src/db/*.py` 后执行 `git check-ignore -v src/db/<file>.py`，避免被错误忽略。
+
+## 安全检查
+
+提交前必须确认：
+
+- 没有真实 `bot_token`、`emby_token`、`api_key`、密码、Cookie secret。
+- 没有上传用户资源、数据库、日志、备份文件。
+- 公开接口有速率限制或明确说明不需要。
+- 管理接口有 `require_auth` 和 `require_admin`。
+- 文件上传和静态资源访问走受控接口，不直接暴露上传目录。
+
+## 维护者合并流程
+
+维护者在合并前执行：
+
+```bash
+git status --short --branch
+git diff
+git log --oneline -10
+```
+
+确认无误后：
+
+```bash
+git switch dev
+git push origin dev
+git switch main
+git pull --ff-only origin main
+git merge --no-ff dev
+git push origin main
+```
+
+发布版本时：
+
+```bash
+git tag v0.0.1
+git push origin v0.0.1
+```
+
+如果维护者使用 GitHub PR，则由 `dev` 创建 PR 到 `main`，检查通过后合并。
+
+## 冲突处理
+
+- 不使用 `git reset --hard` 清理他人改动。
+- 不随意 `git checkout -- <file>` 回退文件。
+- 冲突发生时先确认冲突来源，再由维护者决定保留哪边。
+- 配置、数据库、锁文件、生成物冲突优先不提交，除非明确属于版本内容。
+
+## 版本发布流程
+
+1. 在 `dev` 更新版本号和 `docs/VERSION_HISTORY.md`。
+2. 运行验证。
+3. 维护者检查 diff。
+4. 维护者 push `dev`。
+5. 维护者合并到 `main`。
+6. 维护者打 tag。
+7. 发布更新说明。

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,12 +25,15 @@
 | ---- | ---- |
 | [前端开发](./FRONTEND.md) | Next.js 前端本地开发与联调 |
 | [开发指南](./DEVELOPMENT.md) | 编码规范、调试、关键架构决策 |
+| [开发者流程](./DEVELOPER_WORKFLOW.md) | Git 分支、开发验证、维护者合并与发布流程 |
+| [版本更新与规划](./VERSION_HISTORY.md) | 版本号、功能地图、路线图和发布检查清单 |
 
 ## 专题
 
 - [背景自定义](./BACKGROUND.md) — 用户自定义主题背景的实现
 - [Telegram Bot 命令](./TG_BOT_COMMANDS.md) — Bot 普通命令、管理员命令、群组管理工具
 - [注册码与卡码说明](./REGCODES.md) — 卡码类型、生成格式、兼容性与安全口径
+- [版本更新与规划](./VERSION_HISTORY.md) — 当前版本、功能地图和后续版本步进流程
 - [安全加固指南](./SECURITY.md) — 生产安全基线、密钥与部署检查清单
 - [安全与性能优化记录](./SECURITY_AND_PERFORMANCE_REVIEW.md) — 上传资源、注册队列、定时任务与管理接口加固
 

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -1,0 +1,150 @@
+# 版本更新与功能规划
+
+本文档记录 Twilight 的版本号、更新内容、功能边界和后续版本推进流程。当前基线版本为 `0.0.1`。
+
+## 版本策略
+
+Twilight 使用语义化版本号：`MAJOR.MINOR.PATCH`。
+
+| 位置 | 含义 |
+| ---- | ---- |
+| `MAJOR` | 破坏性变更、数据模型不兼容、部署方式重大调整。 |
+| `MINOR` | 新功能、新模块、兼容性增强。 |
+| `PATCH` | Bug 修复、安全修复、文档补充、无破坏性小改动。 |
+
+当前项目仍处于早期整理阶段，`0.x` 版本默认表示 API、配置项和数据库结构仍可能调整。进入 `1.0.0` 前必须完成核心功能冻结、迁移策略、测试覆盖和发布流程固化。
+
+## 当前版本
+
+### `0.0.1` - 基线整理版本
+
+发布日期：2026-05-21
+
+定位：建立统一版本号、整理现有功能地图、明确开发分支和发布流程。
+
+更新内容：
+
+- 将后端包版本、后端运行时版本、前端包版本统一设置为 `0.0.1`。
+- 新增版本更新与功能规划文档。
+- 新增开发者开发流程文档。
+- 明确后续开发必须在 `dev` 分支进行，完成后由仓库维护者手动 push 并合并到 `main`。
+- 整理当前项目已存在的后端 API、业务服务、数据库模块、Telegram Bot、前端页面和文档体系。
+
+## 功能地图
+
+### 后端 API
+
+| 模块 | 路径前缀 | 当前能力 |
+| ---- | -------- | -------- |
+| Auth | `/api/v1/auth` | 登录、登出、会话刷新、当前用户、API Key 管理、Telegram/API Key 登录入口。 |
+| Users | `/api/v1/users` | 注册、个人资料、密码、Emby 绑定/补建、注册码使用、续期、Telegram 绑定、头像和背景资源。 |
+| Admin | `/api/v1/admin` | 用户管理、注册队列处理、注册码管理、Emby 管理、求片审核、邀请树、公告、调度任务、Telegram 管理工具。 |
+| System | `/api/v1/system` | 系统信息、健康检查、Emby 线路、配置 schema、配置保存、配置清理、管理统计、在线更新。 |
+| Emby | `/api/v1/emby` | Emby 状态、媒体库、搜索、最新媒体、会话数；旧线路接口返回弃用提示。 |
+| Media | `/api/v1/media` | TMDB/Bangumi 搜索、媒体详情、库存检查、求片提交和用户求片管理。 |
+| API Key | `/api/v1/apikey` | 外部系统专用认证、状态、启停、续期、权限、Emby 操作和卡码使用。 |
+| Batch | `/api/v1/batch` | 批量用户操作、导出、播放统计批量查询和提醒。 |
+| Stats | `/api/v1/stats` | 当前用户和管理员视角播放统计。 |
+| Security | `/api/v1/security` | 登录历史、设备管理、IP 黑名单、可疑行为。 |
+| Invite | `/api/v1/invite` | 邀请配置、邀请码生成/删除/使用、邀请状态。 |
+| Signin | `/api/v1/signin` | 签到配置、签到、签到历史、积分摘要。 |
+| Announcements | `/api/v1/announcements` | 公开公告列表。 |
+| OpenAPI | `/api/v1/openapi.json`、`/api/v1/docs` | 运行时 API 描述和 Swagger UI。 |
+
+### 业务服务
+
+| 服务 | 文件 | 当前能力 |
+| ---- | ---- | -------- |
+| 用户服务 | `src/services/user_service.py` | 注册、待补建 Emby、续期、白名单、密码、角色、Emby 同步。 |
+| Emby 客户端 | `src/services/emby.py`、`emby_service.py` | Emby 认证、用户、媒体库、会话、活动、策略同步。 |
+| 注册队列 | `emby_register_queue.py`、`regcode_use_queue.py` | Emby 补建和卡码使用的排队、状态查询、限流和 token 校验。 |
+| 邀请服务 | `invite_service.py` | 邀请关系、邀请码、邀请树、被邀请用户处理。 |
+| 求片服务 | `media_service.py` | 搜索聚合、库存检查、求片状态流转。 |
+| Bangumi | `bangumi.py`、`bangumi_search.py`、`bangumi_sync.py` | Bangumi 搜索、条目同步、观看记录同步。 |
+| TMDB | `tmdb.py` | TMDB 搜索和详情。 |
+| Telegram | `telegram_runtime.py`、`telegram_membership.py` | Bot 运行时、群成员校验、退群处理。 |
+| 安全服务 | `security_service.py` | 登录审计、设备、IP 黑名单。 |
+| 签到服务 | `signin_service.py` | 签到、积分、连续签到奖励。 |
+| 定时任务 | `scheduler_service.py` | APScheduler、任务计划、运行历史、手动触发。 |
+| 系统更新 | `system_update_service.py` | Git 更新检查和管理员触发更新。 |
+| 通知 | `notification.py` | 站内/外部通知聚合入口。 |
+
+### 数据库模块
+
+| 模块 | 文件 | 数据 |
+| ---- | ---- | ---- |
+| 用户 | `src/db/user.py` | 用户、角色、Telegram 绑定码、换绑申请。 |
+| 注册码 | `src/db/regcode.py` | 注册码、续期码、白名单码、诱饵码、使用记录。 |
+| API Key | `src/db/apikey.py` | API Key、权限、启停状态。 |
+| 邀请 | `src/db/invite.py` | 邀请码和邀请关系。 |
+| 求片 | `src/db/require.py`、`bangumi.py` | TMDB/Bangumi 求片请求。 |
+| 播放 | `src/db/playback.py` | 播放历史与统计来源。 |
+| 登录 | `src/db/login_log.py` | 登录历史、设备和客户端信息。 |
+| 签到 | `src/db/signin.py` | 签到记录、积分流水。 |
+| 公告 | `src/db/announcement.py` | 公告内容、可见性、过期时间。 |
+| 调度 | `src/db/scheduler_schedule.py`、`scheduler_run.py` | 任务计划覆盖与运行历史。 |
+| Telegram 花名册 | `src/db/telegram_roster.py` | 群成员观察记录。 |
+
+### 前端页面
+
+| 区域 | 页面 |
+| ---- | ---- |
+| 认证 | 登录、注册、忘记密码。 |
+| 用户 | 仪表盘、媒体搜索/求片、签到积分、邀请码、公告、设置、外观、背景、API Key。 |
+| 管理 | 用户管理、Emby 管理、注册码管理、配置管理、定时任务、公告管理、求片管理、邀请管理、统计、Telegram 换绑申请、系统测试页。 |
+| 测试/演示 | `testweb*` 页面用于 UI/交互验证，不应作为生产入口依赖。 |
+
+### Telegram Bot
+
+| 模块 | 能力 |
+| ---- | ---- |
+| 用户命令 | `/start`、绑定、个人信息、帮助、基础 Emby 信息。 |
+| 管理命令 | 用户查询、Bot 状态、Emby 状态、管理辅助操作。 |
+| 群组管理 | 群内用户查询、管理员身份校验、退群/成员资格相关处理。 |
+
+### 文档体系
+
+| 文档 | 用途 |
+| ---- | ---- |
+| `README.md` | 项目入口、功能概览、快速文档链接。 |
+| `docs/README.md` | 文档导航。 |
+| `docs/INSTALL.md` | 部署安装。 |
+| `docs/FRONTEND.md` | 前端开发和联调。 |
+| `docs/DEVELOPMENT.md` | 架构决策和编码规则。 |
+| `docs/DEVELOPER_WORKFLOW.md` | Git 分支、开发、验证、合并流程。 |
+| `docs/BACKEND_API.md`、`API_INDEX.md`、`API_KEY_API.md` | API 规范和索引。 |
+| `docs/REGCODES.md` | 卡码类型、生成、安全和兼容性。 |
+| `docs/SECURITY.md` | 生产安全基线。 |
+
+## 后续版本规划
+
+| 版本 | 目标 |
+| ---- | ---- |
+| `0.0.2` | 补齐核心回归测试、补充配置 schema 校验、整理公开/管理员接口鉴权矩阵。 |
+| `0.1.0` | 完成注册/Emby/注册码/邀请/求片的稳定闭环，形成可公开试用版本。 |
+| `0.2.0` | 强化管理后台体验、批量操作安全确认、运行状态观测和审计导出。 |
+| `0.3.0` | 完善 Telegram Bot 面板、群组成员策略、通知与公告联动。 |
+| `0.4.0` | 完成部署体验优化、配置迁移策略、备份恢复文档。 |
+| `1.0.0` | API、配置和数据库迁移策略稳定，核心功能测试通过，发布流程冻结。 |
+
+## 版本步进流程
+
+1. 所有开发从 `dev` 分支开始，不直接在 `main` 开发。
+2. 开发前确认 `dev` 基于最新 `main`。
+3. 修改代码、配置或文档时同步更新对应文档。
+4. 若变更用户可见功能或行为，更新本文件的“未发布”记录或新增目标版本段落。
+5. 发布前统一更新版本号位置：`src/__init__.py`、`pyproject.toml`、`webui/package.json`、`webui/package-lock.json`。
+6. 运行验证：至少执行 Python 编译检查、前端 lint；涉及接口或业务流程时补充专项测试。
+7. 由维护者检查 `git diff`，确认无密钥、无本地配置、无生成物误提交。
+8. 维护者手动 push `dev` 并创建合并请求或本地合并到 `main`。
+9. 合并后由维护者打 tag，例如 `v0.0.1`，并发布变更说明。
+
+## 发布检查清单
+
+- 版本号已更新且前后端一致。
+- 文档已同步更新。
+- `docs/API_INDEX.md` 与新增/变更接口一致。
+- `docs/SECURITY.md` 或相关安全说明已覆盖新增风险。
+- 配置变更已写入 `config.py`、schema、示例配置和迁移规则。
+- 未提交 `config.toml` 中的真实密钥、数据库、上传文件、备份文件。
+- 已在 `dev` 分支完成验证，`main` 仅由维护者合并。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "twilight"
-version = "1.0.0"
+version = "0.0.1"
 description = "Next Generation Emby/Jellyfin Management System"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -9,7 +9,7 @@ Twilight - Emby 用户管理系统
 - 可选的 Telegram Bot 接口
 """
 
-__version__ = "1.0.0"
+__version__ = "0.0.1"
 __author__ = "MoYuanCN"
 
 from src.config import Config, EmbyConfig, TelegramConfig, RegisterConfig

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -13,6 +13,7 @@ from src.api.routes import api, admin_api
 from src.api.v1 import register_v1_blueprints
 from src.config import Config, APIConfig, normalize_storage_settings
 from src.core.utils import setup_logging, timestamp
+from src import __version__
 from src.core.request_utils import get_real_client_ip  # noqa: F401 - re-export for convenience
 
 
@@ -119,7 +120,7 @@ def create_app() -> Flask:
         return jsonify(
             {
                 "name": "Twilight API",
-                "version": "1.0.0",
+                "version": __version__,
                 "api_versions": ["v1"],
                 "docs": "/api/v1/docs",
             }

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twilight-webui",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twilight-webui",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@opennextjs/cloudflare": "^1.19.8",
         "@radix-ui/react-accordion": "^1.2.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilight-webui",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Add developer workflow and version history docs (docs/DEVELOPER_WORKFLOW.md, docs/VERSION_HISTORY.md) and update README/docs index links. Bump project version to 0.0.1 in pyproject.toml, src/__init__.py and webui/package.json, and make the API report the package __version__ in its metadata response (src/api/__init__.py). These changes establish the baseline release and document the development/release workflow.