### PR TITLE
Add TestWeb demo API and CSRF/rate-limit

### DIFF
--- a/docs/API_INDEX.md
+++ b/docs/API_INDEX.md
@@ -284,6 +284,18 @@
 | POST | `/signin` | User | 签到 |
 | GET | `/signin/history` | User | 签到历史 |
 
+## Demo
+
+| 方法 | 路径 | 认证 | 说明 |
+| ---- | ---- | ---- | ---- |
+| GET | `/demo/bootstrap` | Public | TestWeb 演示聚合数据，返回预设假数据 |
+| GET | `/demo/auth/me` | Public | TestWeb 演示当前用户 |
+| GET | `/demo/system/info` | Public | TestWeb 演示系统信息 |
+| GET | `/demo/admin/users` | Public | TestWeb 演示用户列表 |
+| GET | `/demo/admin/regcodes` | Public | TestWeb 演示注册码列表 |
+| GET | `/demo/media/search` | Public | TestWeb 演示媒体搜索 |
+| POST/PUT/DELETE | `/demo/action/{action_name}` | Public | TestWeb 演示写操作模拟结果；忽略请求体，不执行真实操作 |
+
 ## API Key
 
 | 方法 | 路径 | 认证 | 说明 |
@@ -295,7 +307,7 @@
 | POST | `/apikey/renew` | API Key | 续期当前账号 |
 | POST | `/apikey/key/refresh` | API Key | 刷新 API Key |
 | GET | `/apikey/permissions` | API Key | 权限列表 |
-| PUT | `/apikey/permissions` | API Key | 更新权限 |
+| PUT | `/apikey/permissions` | API Key | 禁止：API Key 不能自行修改权限 |
 | POST | `/apikey/key/disable` | API Key | 禁用 Key |
 | POST | `/apikey/key/enable` | API Key | 启用 Key |
 | GET | `/apikey/emby/status` | API Key | Emby 状态 |

--- a/docs/API_KEY_API.md
+++ b/docs/API_KEY_API.md
@@ -74,7 +74,8 @@ API Key 支持细粒度权限控制，部分接口只在特定权限下可用。
 | `/key/enable` | `account:write` |
 | `/emby/status` | `emby:read` |
 | `/emby/kick` | `emby:write` |
-| `/permissions` | 无（仅需有效 API Key） |
+| `GET /permissions` | 无（仅需有效 API Key） |
+| `PUT /permissions` | 禁止 API Key 自行调用；请在 Web 端管理 |
 | `/use-code` | `account:write` |
 
 ## 5. 关键接口
@@ -86,6 +87,7 @@ API Key 支持细粒度权限控制，部分接口只在特定权限下可用。
 `GET /api/v1/apikey/info`
 
 - 认证：API Key
+- 权限：`account:write`
 - 请求头：
   - `X-API-Key: key-xxxxxxxxxxxxxxxx-yyyyyyyy`
 - 说明：查询当前 API Key 对应账号的完整信息。
@@ -101,6 +103,7 @@ curl -X GET "https://your-domain.com/api/v1/apikey/info" \
 `GET /api/v1/apikey/status`
 
 - 认证：API Key
+- 权限：`account:write`
 - 请求头：
   - `X-API-Key: key-xxxxxxxxxxxxxxxx-yyyyyyyy`
 - 说明：获取账号激活状态、过期时间、剩余天数和是否被禁用。
@@ -118,6 +121,7 @@ curl -X GET "https://your-domain.com/api/v1/apikey/status" \
 `POST /api/v1/apikey/enable`
 
 - 认证：API Key
+- 权限：`account:write`
 - 请求头：
   - `X-API-Key: key-xxxxxxxxxxxxxxxx-yyyyyyyy`
 - 说明：启用当前账号。
@@ -428,4 +432,4 @@ A: 是的，单次续期天数通常限制在 1-3650 天（10 年）之间。
 
 ### Q: 如何查看当前 API Key 的可用权限？
 
-A: 使用 `/api/v1/apikey/permissions`（GET）获取当前权限与完整权限列表；可通过同路径 `PUT` 更新权限集。
+A: 使用 `/api/v1/apikey/permissions`（GET）获取当前权限与完整权限列表；权限修改只能在 Web 端个人设置中完成，API Key 不能自行调用 `PUT /permissions` 提权。

--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -147,6 +147,17 @@ Authorization: ApiKey <api_key>
 | Stats | `/stats` | 播放统计 |
 | System | `/system` | 健康、系统信息、配置、路由列表 |
 | API Key | `/apikey` | 外部系统专用 API Key 接口 |
+| Demo | `/demo` | TestWeb 演示专用模拟接口，只返回假数据 |
+
+### 4.2 TestWeb 演示接口
+
+`/api/v1/demo/*` 仅供 `/testweb`、`/testwebuser`、`/testwebadmin` 演示页面使用。
+
+- 认证：公开，不读取登录态。
+- 数据：全部为后端静态预设假数据，不读取数据库、不读取登录态、不调用真实业务服务。
+- 写操作：统一返回 `simulated=true`，忽略请求体，不回显用户输入，不写数据库、不调用 Emby、不调用 Telegram。
+- 响应：统一带 `Cache-Control: no-store` 和 `X-Twilight-Demo: true`，避免缓存演示响应。
+- 生产建议：可通过反向代理限制公开访问，避免访客误以为是真实后台。
 
 ### 4.1 命名与归属约定
 

--- a/docs/DEVELOPER_WORKFLOW.md
+++ b/docs/DEVELOPER_WORKFLOW.md
@@ -95,6 +95,14 @@ pytest
 - 涉及认证态、系统配置、区域刷新时复用已有 store/hook。
 - 新页面必须考虑桌面和移动端基本可用。
 
+## 修改 TestWeb 演示的规则
+
+- `/testweb`、`/testwebuser`、`/testwebadmin` 只能调用 `/api/v1/demo/*`。
+- TestWeb 不读取真实登录态，不调用真实用户、管理员、Emby、注册、求片、配置接口。
+- 需要新增演示数据时，先在 `src/api/v1/demo.py` 增加预设假数据，再让前端读取该字段。
+- `src/api/v1/demo.py` 禁止导入 `src.db.*`、`src.services.*` 或读取 `g.current_user` / Cookie / Authorization。
+- 演示按钮可以调用 `/demo/action/{action_name}`，但该接口必须忽略请求体，只返回 `simulated=true`，不得回显用户输入、写库或调用外部服务。
+
 ## 修改数据库的规则
 
 - 现有数据库按模块拆分在 `src/db/*.py`。

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -29,6 +29,7 @@ cors_origins = ["https://app.example.com"]
 - 若通过 HTTPS 对外提供服务，建议同时启用：
   - `session_cookie_secure = true`
   - 合理的 `session_cookie_samesite`（通常 `Lax`）
+- 使用 Cookie 会话执行写操作时，前端必须带 `X-Twilight-Client: webui`；后端会拒绝缺少该头的 Cookie 写请求，用于阻断 CSRF 表单提交。
 
 ## 3. Telegram 相关安全
 
@@ -74,6 +75,7 @@ cors_origins = ["https://app.example.com"]
 ## 7. 最小权限原则
 
 - API Key 仅授予必要 scope。
+- API Key 不能自行修改权限；权限变更必须通过已登录 Web 端完成，避免只读 Key 自提权。
 - 管理员账号数量最小化，长期不使用的高权限账号及时停用。
 - Telegram 管理员 ID 仅配置必要人员。
 

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -49,6 +49,7 @@ Twilight 使用语义化版本号：`MAJOR.MINOR.PATCH`。
 | Invite | `/api/v1/invite` | 邀请配置、邀请码生成/删除/使用、邀请状态。 |
 | Signin | `/api/v1/signin` | 签到配置、签到、签到历史、积分摘要。 |
 | Announcements | `/api/v1/announcements` | 公开公告列表。 |
+| Demo | `/api/v1/demo` | TestWeb 演示专用模拟接口，只返回静态预设假数据；模拟操作忽略请求体，不触碰数据库或外部服务。 |
 | OpenAPI | `/api/v1/openapi.json`、`/api/v1/docs` | 运行时 API 描述和 Swagger UI。 |
 
 ### 业务服务
@@ -92,7 +93,7 @@ Twilight 使用语义化版本号：`MAJOR.MINOR.PATCH`。
 | 认证 | 登录、注册、忘记密码。 |
 | 用户 | 仪表盘、媒体搜索/求片、签到积分、邀请码、公告、设置、外观、背景、API Key。 |
 | 管理 | 用户管理、Emby 管理、注册码管理、配置管理、定时任务、公告管理、求片管理、邀请管理、统计、Telegram 换绑申请、系统测试页。 |
-| 测试/演示 | `testweb*` 页面用于 UI/交互验证，不应作为生产入口依赖。 |
+| 测试/演示 | `testweb*` 页面复刻真实前端主要界面，但只调用 `/api/v1/demo/*` 模拟接口，不执行真实业务操作。 |
 
 ### Telegram Bot
 
@@ -115,17 +116,6 @@ Twilight 使用语义化版本号：`MAJOR.MINOR.PATCH`。
 | `docs/BACKEND_API.md`、`API_INDEX.md`、`API_KEY_API.md` | API 规范和索引。 |
 | `docs/REGCODES.md` | 卡码类型、生成、安全和兼容性。 |
 | `docs/SECURITY.md` | 生产安全基线。 |
-
-## 后续版本规划
-
-| 版本 | 目标 |
-| ---- | ---- |
-| `0.0.2` | 补齐核心回归测试、补充配置 schema 校验、整理公开/管理员接口鉴权矩阵。 |
-| `0.1.0` | 完成注册/Emby/注册码/邀请/求片的稳定闭环，形成可公开试用版本。 |
-| `0.2.0` | 强化管理后台体验、批量操作安全确认、运行状态观测和审计导出。 |
-| `0.3.0` | 完善 Telegram Bot 面板、群组成员策略、通知与公告联动。 |
-| `0.4.0` | 完成部署体验优化、配置迁移策略、备份恢复文档。 |
-| `1.0.0` | API、配置和数据库迁移策略稳定，核心功能测试通过，发布流程冻结。 |
 
 ## 版本步进流程
 

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -78,7 +78,7 @@ def create_app() -> Flask:
             app,
             resources={r"/api/*": {"origins": cors_origins}},
             supports_credentials=not allow_all,
-            allow_headers=["Content-Type", "Authorization", "X-API-Key"],
+            allow_headers=["Content-Type", "Authorization", "X-API-Key", "X-Twilight-Client"],
             methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
             max_age=3600,
         )

--- a/src/api/v1/__init__.py
+++ b/src/api/v1/__init__.py
@@ -19,6 +19,7 @@ from src.api.v1.apikey import apikey_bp
 from src.api.v1.announcements import announcements_bp
 from src.api.v1.invite import invite_bp
 from src.api.v1.signin import signin_bp
+from src.api.v1.demo import demo_bp
 
 # 创建 v1 API 蓝图
 api_v1 = Blueprint("api_v1", __name__, url_prefix="/api/v1")
@@ -43,6 +44,7 @@ def register_v1_blueprints(app):
     app.register_blueprint(announcements_bp, url_prefix="/api/v1/announcements")
     app.register_blueprint(invite_bp, url_prefix="/api/v1/invite")
     app.register_blueprint(signin_bp, url_prefix="/api/v1/signin")
+    app.register_blueprint(demo_bp, url_prefix="/api/v1/demo")
 
 
 __all__ = [
@@ -61,4 +63,5 @@ __all__ = [
     "announcements_bp",
     "invite_bp",
     "signin_bp",
+    "demo_bp",
 ]

--- a/src/api/v1/apikey.py
+++ b/src/api/v1/apikey.py
@@ -416,6 +416,7 @@ async def renew_account():
 
 @apikey_bp.route("/key/refresh", methods=["POST"])
 @require_apikey
+@require_permission("account:write")
 async def refresh_apikey():
     """
     刷新 API Key（生成新的 API Key，旧的立即失效）
@@ -488,35 +489,12 @@ async def update_permissions():
             "permissions": ["account:read", "media:read"]
         }
     """
-    data = request.get_json() or {}
-    permissions = data.get("permissions")
-
-    if permissions is None:
-        return api_response(False, "缺少 permissions 参数", code=400)
-
-    if not isinstance(permissions, list):
-        return api_response(False, "permissions 必须是数组", code=400)
-
-    # 验证权限值
-    invalid = [p for p in permissions if p not in ALL_PERMISSIONS]
-    if invalid:
-        return api_response(False, f"无效的权限: {', '.join(invalid)}", code=400)
-
-    user = g.current_user
-    user.APIKEY_PERMISSIONS = json.dumps(permissions)
-    await UserOperate.update_user(user)
-
-    return api_response(
-        True,
-        "权限已更新",
-        {
-            "permissions": permissions,
-        },
-    )
+    return api_response(False, "API Key 不能自行修改权限，请登录 Web 端在个人设置中管理", code=403)
 
 
 @apikey_bp.route("/key/disable", methods=["POST"])
 @require_apikey
+@require_permission("account:write")
 async def disable_apikey():
     """
     禁用当前 API Key
@@ -551,6 +529,7 @@ async def disable_apikey():
 
 @apikey_bp.route("/key/enable", methods=["POST"])
 @require_apikey
+@require_permission("account:write")
 async def enable_apikey():
     """
     启用 API Key（如果不存在则生成）

--- a/src/api/v1/auth.py
+++ b/src/api/v1/auth.py
@@ -236,14 +236,21 @@ def require_auth(f: Callable) -> Callable:
         # 从请求头获取 token
         auth_header = request.headers.get("Authorization", "")
         token = ""
+        token_from_cookie = False
         if auth_header and auth_header.startswith("Bearer "):
             token = auth_header[7:]
         else:
             cookie_name = (APIConfig.SESSION_COOKIE_NAME or _AUTH_COOKIE_NAME).strip() or _AUTH_COOKIE_NAME
             token = (request.cookies.get(cookie_name) or "").strip()
+            token_from_cookie = bool(token)
 
         if not token:
             return api_response(False, "需要认证", code=401)
+
+        if token_from_cookie and request.method not in {"GET", "HEAD", "OPTIONS"}:
+            # Cookie 会自动随跨站请求发送；写操作必须带 JS 可设置的自定义头，阻断表单/图片等 CSRF。
+            if request.headers.get("X-Twilight-Client") != "webui":
+                return api_response(False, "缺少 CSRF 防护请求头", code=403)
 
         # 验证 token 格式（应该是 64 位十六进制字符串）
         if len(token) != 64 or not all(c in "0123456789abcdef" for c in token):

--- a/src/api/v1/demo.py
+++ b/src/api/v1/demo.py
@@ -1,0 +1,202 @@
+"""TestWeb 演示接口。
+
+这些接口只返回预设假数据，供 `/testweb*` 前端演示页面使用。它们不读取登录态、
+不读写数据库、不调用 Emby/Telegram，也不复用真实业务服务。演示写操作也不读取
+请求体，避免用户误输入的内容被回显或进入日志/缓存。
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from flask import Blueprint, request
+
+from src import __version__
+from src.api.v1.auth import api_response
+
+demo_bp = Blueprint("demo", __name__, url_prefix="/demo")
+
+
+DEMO_USER = {
+    "uid": 1001,
+    "username": "demo_user",
+    "telegram_id": 123456789,
+    "email": "de***@example.com",
+    "role": 1,
+    "role_name": "普通用户",
+    "active": True,
+    "expire_status": "42 天后到期",
+    "expired_at": 1770000000,
+    "emby_id": "demo-emby-user-id",
+    "emby_username": "demo_user",
+    "emby_bound": True,
+    "pending_emby": False,
+    "pending_emby_days": None,
+    "bgm_mode": True,
+    "avatar": None,
+    "register_time": 1760000000,
+    "created_at": 1760000000,
+}
+
+DEMO_ADMIN = {
+    **DEMO_USER,
+    "uid": 1,
+    "username": "demo_admin",
+    "role": 0,
+    "role_name": "管理员",
+    "expire_status": "永久",
+    "expired_at": -1,
+}
+
+DEMO_BOOTSTRAP = {
+    "version": __version__,
+    "mode": "demo",
+    "readonly": True,
+    "notice": "TestWeb 使用后端模拟接口，只返回假数据，不执行真实操作。",
+    "user": DEMO_USER,
+    "admin": DEMO_ADMIN,
+    "metrics": {
+        "user": [
+            {"label": "账号状态", "value": "正常", "description": "Emby 已绑定"},
+            {"label": "剩余天数", "value": "42", "description": "到期提醒开启"},
+            {"label": "积分", "value": "1,280", "description": "今日已签到"},
+            {"label": "求片", "value": "3", "description": "1 个已完成"},
+        ],
+        "admin": [
+            {"label": "总用户", "value": "186", "description": "+12 本月"},
+            {"label": "Emby 绑定", "value": "143", "description": "77%"},
+            {"label": "待处理求片", "value": "8", "description": "3 个下载中"},
+            {"label": "定时任务", "value": "11", "description": "9 个启用"},
+        ],
+    },
+    "announcements": [
+        {"id": 1, "title": "维护窗口", "tag": "置顶", "level": "warning", "content": "周六 02:00-03:00 进行线路维护，期间播放可能短暂中断。"},
+        {"id": 2, "title": "新片补全", "tag": "更新", "level": "info", "content": "本周新增 42 部电影与 13 部剧集，求片队列处理完成率 93%。"},
+        {"id": 3, "title": "安全提醒", "tag": "提醒", "level": "notice", "content": "请勿复用弱密码，演示站不会保存或提交任何输入内容。"},
+    ],
+    "requests": [
+        {"id": 101, "title": "The Bear S03", "user": "mika", "status": "pending", "source": "TMDB", "note": "等待下载"},
+        {"id": 102, "title": "葬送的芙莉莲", "user": "akira", "status": "downloading", "source": "BGM", "note": "已加入队列"},
+        {"id": 103, "title": "Dune: Part Two", "user": "nova", "status": "completed", "source": "TMDB", "note": "已入库"},
+    ],
+    "scheduler_runs": [
+        {"name": "过期用户检查", "status": "success", "time": "03:00", "logs": ["扫描用户 186", "禁用过期账号 2", "同步 Emby 完成"]},
+        {"name": "系统自动更新", "status": "success", "time": "04:00", "logs": ["git fetch origin main", "git pull --ff-only", "未安装 Python 依赖"]},
+        {"name": "清理未绑定 Emby", "status": "failed", "time": "手动", "logs": ["dry_run=false", "跳过注册队列 UID 12", "失败：示例错误"]},
+    ],
+    "users": [
+        {"uid": 1, "username": "admin", "role": "管理员", "active": True, "emby": "已绑定", "expire": "永久"},
+        {"uid": 28, "username": "mika", "role": "普通用户", "active": True, "emby": "待补建", "expire": "未绑定"},
+        {"uid": 42, "username": "nova", "role": "白名单", "active": True, "emby": "已绑定", "expire": "永久"},
+        {"uid": 77, "username": "guest", "role": "普通用户", "active": False, "emby": "未绑定", "expire": "未绑定"},
+    ],
+    "regcodes": [
+        {"code": "TW-register-ABCDEFGHJKLMNPQRST", "type": 1, "type_name": "注册", "status": "available", "days": 30, "use_count": 0, "use_count_limit": 1},
+        {"code": "TW-renew-23456789ABCDEFGHJK", "type": 2, "type_name": "续期", "status": "used_up", "days": 90, "use_count": 1, "use_count_limit": 1},
+        {"code": "TW-whitelist-DEMO-CODE-01", "type": 3, "type_name": "白名单", "status": "available", "days": -1, "use_count": 2, "use_count_limit": -1},
+    ],
+    "media": [
+        {"title": "The Bear", "type": "剧集", "year": "2022", "status": "可求片", "rating": "8.6"},
+        {"title": "Dune: Part Two", "type": "电影", "year": "2024", "status": "已入库", "rating": "8.4"},
+        {"title": "Frieren", "type": "动画", "year": "2023", "status": "处理中", "rating": "9.1"},
+    ],
+    "audit_events": [
+        {"actor": "admin", "action": "授予注册队列用户资格", "target": "mika", "level": "warning"},
+        {"actor": "system", "action": "自动更新完成", "target": "main", "level": "success"},
+        {"actor": "bot", "action": "Telegram 换绑审核", "target": "nova", "level": "info"},
+    ],
+    "notifications": [
+        {"type": "bell", "text": "你有 1 个求片已完成"},
+        {"type": "calendar", "text": "账号将在 12 天后到期"},
+        {"type": "search", "text": "模拟搜索不会访问真实业务接口"},
+    ],
+}
+
+
+def _demo_data() -> dict[str, Any]:
+    return deepcopy(DEMO_BOOTSTRAP)
+
+
+def _demo_response(success: bool, message: str, data: Any = None, code: int = 200):
+    """演示接口统一响应：禁止缓存，不设置 Cookie，不回显真实请求内容。"""
+    response, status = api_response(success, message, data, code)
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    response.headers["X-Twilight-Demo"] = "true"
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
+    return response, status
+
+
+@demo_bp.route("/bootstrap", methods=["GET"])
+async def demo_bootstrap():
+    role = (request.args.get("role") or "user").strip().lower()
+    data = _demo_data()
+    data["role"] = "admin" if role == "admin" else "user"
+    data["demo_user"] = data["admin"] if data["role"] == "admin" else data["user"]
+    return _demo_response(True, "获取演示数据成功", data)
+
+
+@demo_bp.route("/auth/me", methods=["GET"])
+async def demo_auth_me():
+    role = (request.args.get("role") or "user").strip().lower()
+    data = _demo_data()["admin" if role == "admin" else "user"]
+    return _demo_response(True, "获取成功", data)
+
+
+@demo_bp.route("/system/info", methods=["GET"])
+async def demo_system_info():
+    return _demo_response(
+        True,
+        "获取成功",
+        {
+            "name": "Twilight TestWeb Demo",
+            "version": __version__,
+            "demo": True,
+            "readonly": True,
+            "features": {
+                "register": True,
+                "media_request": True,
+                "telegram": True,
+                "api_key": True,
+            },
+        },
+    )
+
+
+@demo_bp.route("/admin/users", methods=["GET"])
+async def demo_admin_users():
+    users = _demo_data()["users"]
+    return _demo_response(True, f"共 {len(users)} 个演示用户", {"users": users, "total": len(users), "page": 1, "per_page": 20})
+
+
+@demo_bp.route("/admin/regcodes", methods=["GET"])
+async def demo_admin_regcodes():
+    regcodes = _demo_data()["regcodes"]
+    return _demo_response(True, f"共 {len(regcodes)} 个演示卡码", {"regcodes": regcodes, "total": len(regcodes), "page": 1, "per_page": 20})
+
+
+@demo_bp.route("/media/search", methods=["GET"])
+async def demo_media_search():
+    keyword = (request.args.get("q") or request.args.get("keyword") or "").strip().lower()
+    media = _demo_data()["media"]
+    if keyword:
+        media = [item for item in media if keyword in item["title"].lower()]
+    return _demo_response(True, "搜索成功", {"results": media, "total": len(media), "demo": True})
+
+
+@demo_bp.route("/action", methods=["POST"])
+@demo_bp.route("/action/<path:action_name>", methods=["POST", "PUT", "DELETE"])
+async def demo_action(action_name: str = "generic"):
+    safe_action = "".join(ch for ch in str(action_name or "generic") if ch.isalnum() or ch in ("-", "_"))[:64]
+    return _demo_response(
+        True,
+        "演示操作已模拟完成，未执行真实写入",
+        {
+            "simulated": True,
+            "readonly": True,
+            "action": safe_action or "generic",
+            "request_body_ignored": True,
+        },
+    )

--- a/src/api/v1/system.py
+++ b/src/api/v1/system.py
@@ -14,7 +14,8 @@ from flask import Blueprint, request, g, send_file
 from sqlalchemy import text
 
 from src.api.v1.auth import require_auth, require_admin, api_response
-from src.core.utils import parse_bool
+from src.core.utils import parse_bool, rate_limit_check
+from src.core.request_utils import get_real_client_ip
 from src.config import (
     Config,
     EmbyConfig,
@@ -27,6 +28,7 @@ from src.config import (
     NotificationConfig,
     TelegramConfig,
     BangumiSyncConfig,
+    ROOT_PATH,
     backup_config_file,
     fill_missing_config_items,
     sweep_config_toml,
@@ -309,6 +311,19 @@ system_bp = Blueprint("system", __name__, url_prefix="/system")
 _IMAGE_MIME_PREFIXES = ("image/",)
 
 
+def _check_public_system_rate_limit(scope: str, *, max_requests: int = 60, window_seconds: int = 60):
+    client_ip = get_real_client_ip()
+    allowed, retry_after = rate_limit_check(
+        f"system_public:{scope}",
+        client_ip,
+        max_requests=max_requests,
+        window_seconds=window_seconds,
+    )
+    if not allowed:
+        return api_response(False, f"请求过于频繁，请在 {retry_after} 秒后重试", code=429)
+    return None
+
+
 def _resolve_local_server_icon_path() -> Optional[Path]:
     """Resolve Config.SERVER_ICON when it points at a local image file."""
     raw = (Config.SERVER_ICON or "").strip()
@@ -322,6 +337,10 @@ def _resolve_local_server_icon_path() -> Optional[Path]:
         path = (Path.cwd() / path).resolve()
     else:
         path = path.resolve()
+    try:
+        path.relative_to(ROOT_PATH)
+    except ValueError:
+        return None
     if not path.is_file():
         return None
     guessed, _ = mimetypes.guess_type(str(path))
@@ -352,6 +371,10 @@ async def get_system_info():
 
     不需要登录即可访问
     """
+    limited = _check_public_system_rate_limit("info", max_requests=60, window_seconds=60)
+    if limited:
+        return limited
+
     # 暴露 Bot 用户名供前端展示/跳转
     telegram_bot_username: Optional[str] = None
     if Config.TELEGRAM_MODE:
@@ -398,6 +421,9 @@ async def get_system_info():
 @system_bp.route("/server-icon", methods=["GET"])
 async def get_server_icon():
     """Serve the configured local server icon, if SERVER_ICON is a local image path."""
+    limited = _check_public_system_rate_limit("server_icon", max_requests=120, window_seconds=60)
+    if limited:
+        return limited
     path = _resolve_local_server_icon_path()
     if not path:
         return api_response(False, "未配置本地图标或文件不存在", code=404)
@@ -408,6 +434,10 @@ async def get_server_icon():
 @system_bp.route("/health", methods=["GET"])
 async def health_check():
     """健康检查"""
+    limited = _check_public_system_rate_limit("health", max_requests=30, window_seconds=60)
+    if limited:
+        return limited
+
     from src.services import get_emby_client
 
     status = {

--- a/webui/src/app/testweb/demo-shell.tsx
+++ b/webui/src/app/testweb/demo-shell.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { ComponentType } from "react";
 import { motion } from "framer-motion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,18 +13,77 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import {
   adminDemoNav,
-  demoAnnouncements,
-  demoAuditEvents,
-  demoMedia,
-  demoNotifications,
-  demoRequests,
-  demoSchedulerRuns,
-  demoUsers,
+  demoAnnouncements as fallbackAnnouncements,
+  demoAuditEvents as fallbackAuditEvents,
+  demoMedia as fallbackMedia,
+  demoNotifications as fallbackNotifications,
+  demoRequests as fallbackRequests,
+  demoSchedulerRuns as fallbackSchedulerRuns,
+  demoUsers as fallbackUsers,
   type DemoNavItem,
   type DemoRole,
   userDemoNav,
 } from "./mock-data";
 import { CheckCircle2, DatabaseZap, Eye, Lock, PlayCircle, RefreshCw, ShieldCheck, Sparkles } from "lucide-react";
+
+const API_BASE = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "");
+
+interface DemoMetric {
+  label: string;
+  value: string;
+  description: string;
+}
+
+interface DemoData {
+  readonly: boolean;
+  notice: string;
+  metrics: Record<DemoRole, DemoMetric[]>;
+  announcements: Array<{ id?: number; title: string; tag: string; content?: string; text?: string }>;
+  requests: Array<{ id?: number; title: string; user: string; status: string; source: string; note: string }>;
+  scheduler_runs: Array<{ name: string; status: string; time: string; logs: string[] }>;
+  users: Array<{ uid: number; username: string; role: string; active: boolean; emby: string; expire: string }>;
+  regcodes: Array<{ code: string; type_name: string; status: string; days: number; use_count: number; use_count_limit: number }>;
+  media: Array<{ title: string; type: string; year: string; status: string; rating: string }>;
+  audit_events: Array<{ actor: string; action: string; target: string; level: string }>;
+  notifications: Array<{ type?: string; text: string; icon?: ComponentType<{ className?: string }> }>;
+}
+
+const fallbackDemoData: DemoData = {
+  readonly: true,
+  notice: "TestWeb 使用本地兜底 mock 数据，不执行真实操作。",
+  metrics: {
+    admin: [
+      { label: "总用户", value: "186", description: "+12 本月" },
+      { label: "Emby 绑定", value: "143", description: "77%" },
+      { label: "待处理求片", value: "8", description: "3 个下载中" },
+      { label: "定时任务", value: "11", description: "9 个启用" },
+    ],
+    user: [
+      { label: "账号状态", value: "正常", description: "Emby 已绑定" },
+      { label: "剩余天数", value: "42", description: "到期提醒开启" },
+      { label: "积分", value: "1,280", description: "今日已签到" },
+      { label: "求片", value: "3", description: "1 个已完成" },
+    ],
+  },
+  announcements: fallbackAnnouncements,
+  requests: fallbackRequests,
+  scheduler_runs: fallbackSchedulerRuns,
+  users: fallbackUsers,
+  regcodes: [
+    { code: "TW-register-DEMO", type_name: "注册", status: "available", days: 30, use_count: 0, use_count_limit: 1 },
+    { code: "TW-renew-DEMO", type_name: "续期", status: "used_up", days: 90, use_count: 1, use_count_limit: 1 },
+  ],
+  media: fallbackMedia,
+  audit_events: fallbackAuditEvents,
+  notifications: fallbackNotifications,
+};
+
+async function postDemoAction(action: string) {
+  await fetch(`${API_BASE}/api/v1/demo/action/${encodeURIComponent(action)}`, {
+    method: "POST",
+    credentials: "omit",
+  }).catch(() => undefined);
+}
 
 function statusVariant(status: string): "default" | "secondary" | "outline" | "destructive" | "success" {
   if (["success", "completed", "已绑定", "已入库"].includes(status)) return "success";
@@ -94,28 +154,16 @@ function DemoHeader({ role, activeLabel }: { role: DemoRole; activeLabel: string
   );
 }
 
-function MetricGrid({ role }: { role: DemoRole }) {
-  const metrics = role === "admin"
-    ? [
-        ["总用户", "186", "+12 本月"],
-        ["Emby 绑定", "143", "77%"],
-        ["待处理求片", "8", "3 个下载中"],
-        ["定时任务", "11", "9 个启用"],
-      ]
-    : [
-        ["账号状态", "正常", "Emby 已绑定"],
-        ["剩余天数", "42", "到期提醒开启"],
-        ["积分", "1,280", "今日已签到"],
-        ["求片", "3", "1 个已完成"],
-      ];
+function MetricGrid({ role, data }: { role: DemoRole; data: DemoData }) {
+  const metrics = data.metrics[role];
   return (
     <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-      {metrics.map(([label, value, desc]) => (
-        <Card key={label}>
+      {metrics.map((metric) => (
+        <Card key={metric.label}>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground">{label}</p>
-            <p className="mt-2 text-2xl font-black">{value}</p>
-            <p className="mt-1 text-xs text-muted-foreground">{desc}</p>
+            <p className="text-xs text-muted-foreground">{metric.label}</p>
+            <p className="mt-2 text-2xl font-black">{metric.value}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{metric.description}</p>
           </CardContent>
         </Card>
       ))}
@@ -123,7 +171,7 @@ function MetricGrid({ role }: { role: DemoRole }) {
   );
 }
 
-function UserPanel({ active }: { active: string }) {
+function UserPanel({ active, data }: { active: string; data: DemoData }) {
   const [query, setQuery] = useState("Dune");
   const [passwordVisible, setPasswordVisible] = useState(false);
   const [apiEnabled, setApiEnabled] = useState(false);
@@ -136,12 +184,12 @@ function UserPanel({ active }: { active: string }) {
           <CardContent className="space-y-4">
             <Input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="搜索媒体" />
             <div className="grid gap-3 md:grid-cols-3">
-              {demoMedia.filter((m) => m.title.toLowerCase().includes(query.toLowerCase()) || !query).map((m) => (
+              {data.media.filter((m) => m.title.toLowerCase().includes(query.toLowerCase()) || !query).map((m) => (
                 <Card key={m.title} className="bg-muted/30">
                   <CardContent className="space-y-2 p-4">
                     <div className="flex items-start justify-between gap-2"><h3 className="font-bold">{m.title}</h3><Badge variant={statusVariant(m.status)}>{m.status}</Badge></div>
                     <p className="text-sm text-muted-foreground">{m.type} · {m.year} · 评分 {m.rating}</p>
-                    <Button size="sm" className="w-full" disabled={m.status === "已入库"}>{m.status === "已入库" ? "已入库" : "模拟求片"}</Button>
+                    <Button size="sm" className="w-full" disabled={m.status === "已入库"} onClick={() => void postDemoAction("media-request")}>{m.status === "已入库" ? "已入库" : "模拟求片"}</Button>
                   </CardContent>
                 </Card>
               ))}
@@ -176,39 +224,45 @@ function UserPanel({ active }: { active: string }) {
 
   return (
     <div className="space-y-4">
-      <MetricGrid role="user" />
+      <MetricGrid role="user" data={data} />
       <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
-        <Card><CardHeader><CardTitle>我的求片记录</CardTitle></CardHeader><CardContent className="space-y-2">{demoRequests.map((r) => <div key={r.title} className="flex items-center justify-between rounded-xl border p-3 text-sm"><span>{r.title}</span><Badge variant={statusVariant(r.status)}>{r.status}</Badge></div>)}</CardContent></Card>
-        <Card><CardHeader><CardTitle>公告与通知</CardTitle></CardHeader><CardContent className="space-y-3">{demoNotifications.map((n) => <div key={n.text} className="flex items-center gap-3 rounded-xl bg-muted/40 p-3 text-sm"><n.icon className="h-4 w-4 text-primary" />{n.text}</div>)}</CardContent></Card>
+        <Card><CardHeader><CardTitle>我的求片记录</CardTitle></CardHeader><CardContent className="space-y-2">{data.requests.map((r) => <div key={r.title} className="flex items-center justify-between rounded-xl border p-3 text-sm"><span>{r.title}</span><Badge variant={statusVariant(r.status)}>{r.status}</Badge></div>)}</CardContent></Card>
+        <Card><CardHeader><CardTitle>公告与通知</CardTitle></CardHeader><CardContent className="space-y-3">{data.notifications.map((n) => {
+          const Icon = n.icon || Sparkles;
+          return <div key={n.text} className="flex items-center gap-3 rounded-xl bg-muted/40 p-3 text-sm"><Icon className="h-4 w-4 text-primary" />{n.text}</div>;
+        })}</CardContent></Card>
       </div>
     </div>
   );
 }
 
-function AdminPanel({ active }: { active: string }) {
+function AdminPanel({ active, data }: { active: string; data: DemoData }) {
   if (active === "users") {
     return (
-      <Card><CardHeader><CardTitle>用户管理</CardTitle><CardDescription>包含注册队列清理与授权演示。</CardDescription></CardHeader><CardContent className="space-y-3">{demoUsers.map((u) => <div key={u.uid} className="grid gap-2 rounded-xl border p-3 text-sm md:grid-cols-[60px_1fr_100px_100px_100px_auto]"><span>#{u.uid}</span><b>{u.username}</b><Badge variant="outline">{u.role}</Badge><Badge variant={u.active ? "success" : "destructive"}>{u.active ? "启用" : "禁用"}</Badge><Badge variant={statusVariant(u.emby)}>{u.emby}</Badge><Button size="sm" variant="outline">模拟操作</Button></div>)}<div className="flex flex-wrap gap-2 pt-2"><Button>清理注册队列</Button><Button variant="secondary">队列用户授权并清理</Button></div></CardContent></Card>
+      <Card><CardHeader><CardTitle>用户管理</CardTitle><CardDescription>包含注册队列清理与授权演示。</CardDescription></CardHeader><CardContent className="space-y-3">{data.users.map((u) => <div key={u.uid} className="grid gap-2 rounded-xl border p-3 text-sm md:grid-cols-[60px_1fr_100px_100px_100px_auto]"><span>#{u.uid}</span><b>{u.username}</b><Badge variant="outline">{u.role}</Badge><Badge variant={u.active ? "success" : "destructive"}>{u.active ? "启用" : "禁用"}</Badge><Badge variant={statusVariant(u.emby)}>{u.emby}</Badge><Button size="sm" variant="outline" onClick={() => void postDemoAction("admin-user")}>模拟操作</Button></div>)}<div className="flex flex-wrap gap-2 pt-2"><Button onClick={() => void postDemoAction("clear-registration-queue")}>清理注册队列</Button><Button variant="secondary" onClick={() => void postDemoAction("grant-registration-entitlement")}>队列用户授权并清理</Button></div></CardContent></Card>
     );
+  }
+  if (active === "regcodes") {
+    return <Card><CardHeader><CardTitle>注册码管理</CardTitle><CardDescription>模拟展示注册码、续期码、白名单码，不会创建或删除真实卡码。</CardDescription></CardHeader><CardContent className="space-y-3">{data.regcodes.map((code) => <div key={code.code} className="grid gap-2 rounded-xl border p-3 text-sm md:grid-cols-[1fr_90px_90px_120px_auto]"><code>{code.code}</code><Badge variant="outline">{code.type_name}</Badge><Badge variant={statusVariant(code.status)}>{code.status}</Badge><span>{code.days <= 0 ? "永久" : `${code.days} 天`}</span><Button size="sm" variant="outline" onClick={() => void postDemoAction("regcode-copy")}>模拟操作</Button></div>)}</CardContent></Card>;
   }
   if (active === "scheduler") {
     return (
-      <Card><CardHeader><CardTitle>定时任务</CardTitle><CardDescription>历史运行可展开查看每次日志。</CardDescription></CardHeader><CardContent className="space-y-3">{demoSchedulerRuns.map((run) => <details key={run.name} className="rounded-xl border p-3"><summary className="flex cursor-pointer items-center justify-between"><span className="font-semibold">{run.name}</span><span className="flex items-center gap-2"><Badge variant={statusVariant(run.status)}>{run.status}</Badge><span className="text-xs text-muted-foreground">{run.time}</span></span></summary><pre className="mt-3 rounded-lg bg-muted p-3 text-xs">{run.logs.join("\n")}</pre></details>)}</CardContent></Card>
+      <Card><CardHeader><CardTitle>定时任务</CardTitle><CardDescription>历史运行可展开查看每次日志。</CardDescription></CardHeader><CardContent className="space-y-3">{data.scheduler_runs.map((run) => <details key={run.name} className="rounded-xl border p-3"><summary className="flex cursor-pointer items-center justify-between"><span className="font-semibold">{run.name}</span><span className="flex items-center gap-2"><Badge variant={statusVariant(run.status)}>{run.status}</Badge><span className="text-xs text-muted-foreground">{run.time}</span></span></summary><pre className="mt-3 rounded-lg bg-muted p-3 text-xs">{run.logs.join("\n")}</pre></details>)}</CardContent></Card>
     );
   }
   if (active === "requests") {
-    return <Card><CardHeader><CardTitle>求片审核</CardTitle></CardHeader><CardContent className="space-y-3">{demoRequests.map((r) => <div key={r.title} className="flex flex-wrap items-center justify-between gap-2 rounded-xl border p-3 text-sm"><div><b>{r.title}</b><p className="text-xs text-muted-foreground">{r.user} · {r.source} · {r.note}</p></div><div className="flex gap-2"><Badge variant={statusVariant(r.status)}>{r.status}</Badge><Button size="sm" variant="outline">审核</Button></div></div>)}</CardContent></Card>;
+    return <Card><CardHeader><CardTitle>求片审核</CardTitle></CardHeader><CardContent className="space-y-3">{data.requests.map((r) => <div key={r.title} className="flex flex-wrap items-center justify-between gap-2 rounded-xl border p-3 text-sm"><div><b>{r.title}</b><p className="text-xs text-muted-foreground">{r.user} · {r.source} · {r.note}</p></div><div className="flex gap-2"><Badge variant={statusVariant(r.status)}>{r.status}</Badge><Button size="sm" variant="outline" onClick={() => void postDemoAction("review-request")}>审核</Button></div></div>)}</CardContent></Card>;
   }
   if (active === "security") {
-    return <Card><CardHeader><CardTitle>安全审计</CardTitle></CardHeader><CardContent className="space-y-3">{demoAuditEvents.map((e) => <div key={`${e.actor}-${e.action}`} className="flex items-center justify-between rounded-xl border p-3 text-sm"><span><b>{e.actor}</b> {e.action} <span className="text-muted-foreground">{e.target}</span></span><Badge variant={statusVariant(e.level)}>{e.level}</Badge></div>)}</CardContent></Card>;
+    return <Card><CardHeader><CardTitle>安全审计</CardTitle></CardHeader><CardContent className="space-y-3">{data.audit_events.map((e) => <div key={`${e.actor}-${e.action}`} className="flex items-center justify-between rounded-xl border p-3 text-sm"><span><b>{e.actor}</b> {e.action} <span className="text-muted-foreground">{e.target}</span></span><Badge variant={statusVariant(e.level)}>{e.level}</Badge></div>)}</CardContent></Card>;
   }
   return (
     <div className="space-y-4">
-      <MetricGrid role="admin" />
+      <MetricGrid role="admin" data={data} />
       <div className="grid gap-4 xl:grid-cols-3">
-        {demoAnnouncements.map((a) => <Card key={a.title}><CardHeader><CardTitle className="flex items-center justify-between text-base">{a.title}<Badge variant="outline">{a.tag}</Badge></CardTitle></CardHeader><CardContent className="text-sm text-muted-foreground">{a.text}</CardContent></Card>)}
+        {data.announcements.map((a) => <Card key={a.title}><CardHeader><CardTitle className="flex items-center justify-between text-base">{a.title}<Badge variant="outline">{a.tag}</Badge></CardTitle></CardHeader><CardContent className="text-sm text-muted-foreground">{a.content || a.text}</CardContent></Card>)}
       </div>
-      <Card><CardHeader><CardTitle>管理快捷操作</CardTitle></CardHeader><CardContent className="flex flex-wrap gap-2"><Button><PlayCircle className="mr-2 h-4 w-4" />运行任务</Button><Button variant="outline"><RefreshCw className="mr-2 h-4 w-4" />同步绑定</Button><Button variant="secondary"><CheckCircle2 className="mr-2 h-4 w-4" />批量启用</Button></CardContent></Card>
+      <Card><CardHeader><CardTitle>管理快捷操作</CardTitle></CardHeader><CardContent className="flex flex-wrap gap-2"><Button onClick={() => void postDemoAction("run-job")}><PlayCircle className="mr-2 h-4 w-4" />运行任务</Button><Button variant="outline" onClick={() => void postDemoAction("sync-bindings")}><RefreshCw className="mr-2 h-4 w-4" />同步绑定</Button><Button variant="secondary" onClick={() => void postDemoAction("bulk-enable")}><CheckCircle2 className="mr-2 h-4 w-4" />批量启用</Button></CardContent></Card>
     </div>
   );
 }
@@ -216,7 +270,23 @@ function AdminPanel({ active }: { active: string }) {
 export function TestWebDemo({ role }: { role: DemoRole }) {
   const nav = role === "admin" ? adminDemoNav : userDemoNav;
   const [active, setActive] = useState(nav[0].key);
+  const [data, setData] = useState<DemoData>(fallbackDemoData);
   const activeLabel = useMemo(() => nav.find((item) => item.key === active)?.label || nav[0].label, [active, nav]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${API_BASE}/api/v1/demo/bootstrap?role=${role}`, { credentials: "omit" })
+      .then((res) => res.json())
+      .then((res) => {
+        if (!cancelled && res?.success && res.data) {
+          setData({ ...fallbackDemoData, ...res.data });
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [role]);
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,hsl(var(--primary)/0.16),transparent_28rem),linear-gradient(135deg,hsl(var(--background)),hsl(var(--muted)/0.55))]">
@@ -229,7 +299,7 @@ export function TestWebDemo({ role }: { role: DemoRole }) {
               {nav.map((item) => <Button key={item.key} size="sm" variant={active === item.key ? "default" : "outline"} onClick={() => setActive(item.key)}><item.icon className="mr-1.5 h-4 w-4" />{item.label}</Button>)}
             </div>
             <motion.div key={active} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.18 }}>
-              {role === "admin" ? <AdminPanel active={active} /> : <UserPanel active={active} />}
+              {role === "admin" ? <AdminPanel active={active} data={data} /> : <UserPanel active={active} data={data} />}
             </motion.div>
           </main>
         </div>

--- a/webui/src/app/testweb/page.tsx
+++ b/webui/src/app/testweb/page.tsx
@@ -21,7 +21,7 @@ export default function TestWebPage() {
           <div>
             <h1 className="text-4xl font-black tracking-tight">TestWeb 安全演示台</h1>
             <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground">
-              这里完全不连接后端、不读取登录态、不发送 API 请求，仅用本地 mock 数据展示前端用户端与管理端的完整交互外观。
+              这里复刻真实用户端与管理端的主要界面，但只连接 /api/v1/demo 模拟接口；不会读取登录态，也不会执行真实写入操作。
             </p>
           </div>
           <Badge variant="outline" className="w-fit gap-1.5"><ShieldCheck className="h-3.5 w-3.5" />Mock Only</Badge>

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -156,6 +156,7 @@ class ApiClient {
   ): Promise<ApiResponse<T>> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
+      "X-Twilight-Client": "webui",
       ...((options.headers as Record<string, string>) || {}),
     };
 
@@ -201,7 +202,9 @@ class ApiClient {
     formData: FormData,
     method: "POST" | "PUT" = "POST"
   ): Promise<ApiResponse<T>> {
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = {
+      "X-Twilight-Client": "webui",
+    };
 
     const url = `${API_BASE}/api/v1${endpoint}`;
     const methodName = method.toUpperCase();


### PR DESCRIPTION
Introduce a TestWeb demo subsystem and tighten related security. Added src/api/v1/demo.py (static preset demo data and demo-only endpoints) and registered the demo blueprint; demo responses include no-store and X-Twilight-Demo headers and never touch DB or external services. Wire frontend to fetch /api/v1/demo/bootstrap with local fallback and post simulated actions; ApiClient now sends X-Twilight-Client: webui and CORS allows that header. Harden auth and API key handling: require_auth blocks cookie-based write requests that lack X-Twilight-Client to mitigate CSRF; PUT /apikey/permissions now returns 403 (API Keys cannot self-change scopes) and certain apikey operations require account:write permission. Add public rate-limits for a few system endpoints and restrict server-icon local path resolution to the project ROOT_PATH. Update docs to document demo endpoints, API key permission policy and CSRF requirement.