### PR TITLE
Emby expiry handling and cancel permanent expiry

### DIFF
--- a/src/api/v1/admin.py
+++ b/src/api/v1/admin.py
@@ -106,6 +106,7 @@ async def list_users():
 
         # EMBYID 非空即视为已绑定；历史数据可能残留 PENDING_EMBY=True，不能因此把到期显示成未绑定。
         emby_bound = bool(user.EMBYID)
+        emby_disabled_by_expiry = UserService.is_emby_access_expired(user)
         user_list.append(
             {
                 "uid": user.UID,
@@ -121,6 +122,7 @@ async def list_users():
                 "pending_emby": bool(getattr(user, "PENDING_EMBY", False)) and not emby_bound,
                 "pending_emby_days": getattr(user, "PENDING_EMBY_DAYS", None) if not emby_bound else None,
                 "expired_at": user.EXPIRED_AT if emby_bound else None,
+                "emby_disabled_by_expiry": emby_disabled_by_expiry,
                 "register_time": user.REGISTER_TIME,
                 "created_at": user.CREATE_AT or user.REGISTER_TIME,
                 "last_login_time": user.LAST_LOGIN_TIME,
@@ -1123,6 +1125,76 @@ async def renew_user(uid: int):
 
     success, message = await UserService.renew_user(user, days)
     return api_response(success, message)
+
+
+@admin_bp.route("/users/<int:uid>/cancel-permanent", methods=["POST"])
+@require_auth
+@require_admin
+async def cancel_user_permanent_expiry(uid: int):
+    """取消用户 Emby 账号永久有效期，并设置为从现在起 N 天后到期。
+
+    Request:
+        {
+            "days": 30
+        }
+    """
+    from src.core.utils import timestamp, days_to_seconds
+
+    user = await UserOperate.get_user_by_uid(uid)
+    if not user:
+        return api_response(False, "用户不存在", code=404)
+    if not user.EMBYID:
+        return api_response(False, "该用户未绑定 Emby 账号，不能设置 Emby 到期时间", code=400)
+    if user.ROLE == Role.ADMIN.value:
+        return api_response(False, "不允许取消管理员账号的永久有效期", code=403)
+
+    current_expired_at = int(user.EXPIRED_AT or 0)
+    if current_expired_at != -1 and current_expired_at < 253402214400:
+        return api_response(False, "该用户当前不是永久有效期", code=400)
+
+    data = request.get_json(silent=True) or {}
+    try:
+        days = int(data.get("days", 30))
+    except (TypeError, ValueError):
+        return api_response(False, "days 必须是整数", code=400)
+    if days <= 0:
+        return api_response(False, "取消永久有效期时 days 必须大于 0", code=400)
+    if days > 3650:
+        return api_response(False, "days 不能超过 3650", code=400)
+
+    previous_role = user.ROLE
+    user.EXPIRED_AT = timestamp() + days_to_seconds(days)
+    if user.ROLE == Role.WHITE_LIST.value:
+        user.ROLE = Role.NORMAL.value
+    if not user.ACTIVE_STATUS:
+        user.ACTIVE_STATUS = True
+    await UserOperate.update_user(user)
+    try:
+        await UserService.sync_user_to_emby(user)
+    except Exception as exc:
+        logger.warning("取消永久后同步 Emby 状态失败 uid=%s: %s", user.UID, exc)
+
+    logger.warning(
+        "管理员 %s 取消用户永久有效期 uid=%s username=%s days=%s previous_role=%s new_expired_at=%s",
+        getattr(g.current_user, "USERNAME", None),
+        user.UID,
+        user.USERNAME,
+        days,
+        previous_role,
+        user.EXPIRED_AT,
+    )
+    return api_response(
+        True,
+        f"已取消永久有效期，改为 {days} 天后到期" + ("；白名单角色已降级为普通用户" if previous_role == Role.WHITE_LIST.value else ""),
+        {
+            "uid": user.UID,
+            "days": days,
+            "expired_at": user.EXPIRED_AT,
+            "role": user.ROLE,
+            "role_name": Role(user.ROLE).name if user.ROLE in [r.value for r in Role] else "UNKNOWN",
+            "downgraded_whitelist": previous_role == Role.WHITE_LIST.value,
+        },
+    )
 
 
 @admin_bp.route("/emby/force-set-password", methods=["POST"])

--- a/src/api/v1/system.py
+++ b/src/api/v1/system.py
@@ -519,6 +519,7 @@ async def get_emby_urls():
     返回结构化数据: { lines: [{name, url, tag?}], whitelist_lines?: [{name, url, tag?}] }
     """
     from src.db.user import Role
+    from src.services.user_service import UserService
 
     user = getattr(g, "current_user", None)
     is_admin = bool(user and user.ROLE == Role.ADMIN.value)
@@ -536,6 +537,17 @@ async def get_emby_urls():
             {
                 "lines": [],
                 "requires_emby_account": True,
+            },
+        )
+
+    if user and not is_admin and UserService.is_emby_access_expired(user):
+        return api_response(
+            True,
+            "Emby 账号已到期并禁用，续期后恢复线路访问",
+            {
+                "lines": [],
+                "requires_renewal": True,
+                "emby_disabled_by_expiry": True,
             },
         )
 

--- a/src/bot/handlers/admin_handlers.py
+++ b/src/bot/handlers/admin_handlers.py
@@ -298,14 +298,11 @@ def register(bot):
             await answer_callback_safe(query, f"✅ 已禁用 {username}")
 
         elif action == "unban":
-            if user.EMBYID:
-                try:
-                    emby = get_emby_client()
-                    await emby.set_user_enabled(user.EMBYID, True)
-                except Exception as e:
-                    logger.warning(f"解禁 Emby 用户失败: {e}")
             user.ACTIVE_STATUS = True
             await UserOperate.update_user(user)
+            ok, msg = await UserService.sync_user_to_emby(user)
+            if not ok:
+                logger.warning("解禁后同步 Emby 用户失败: %s", msg)
             await answer_callback_safe(query, f"✅ 已解禁 {username}")
 
         elif action == "del":
@@ -724,14 +721,9 @@ def register(bot):
                 await UserOperate.update_user(user)
                 await update.message.reply_text(f"✅ 已禁用用户: `{text}`", parse_mode="Markdown")
             else:
-                if user.EMBYID:
-                    try:
-                        emby = get_emby_client()
-                        await emby.set_user_enabled(user.EMBYID, True)
-                    except Exception:
-                        pass
                 user.ACTIVE_STATUS = True
                 await UserOperate.update_user(user)
+                await UserService.sync_user_to_emby(user)
                 await update.message.reply_text(f"✅ 已解禁用户: `{text}`", parse_mode="Markdown")
             _clear_admin_state(uid)
 
@@ -1219,13 +1211,11 @@ def register(bot):
             await UserOperate.update_user(user)
             message = "已禁用用户"
         elif action == "enable":
-            if user.EMBYID:
-                try:
-                    await get_emby_client().set_user_enabled(user.EMBYID, True)
-                except Exception as exc:
-                    logger.warning("群组启用 Emby 用户失败: %s", exc)
             user.ACTIVE_STATUS = True
             await UserOperate.update_user(user)
+            ok, msg = await UserService.sync_user_to_emby(user)
+            if not ok:
+                logger.warning("群组启用后同步 Emby 用户失败: %s", msg)
             message = "已启用用户"
         elif action == "delete":
             ok, msg = await UserService.delete_user(user, delete_emby=True)

--- a/src/services/admin_service.py
+++ b/src/services/admin_service.py
@@ -85,10 +85,10 @@ class BatchOperationService:
                     errors.append(f"UID {uid}: 用户不存在")
                     continue
 
-                if user.EMBYID:
-                    await emby.set_user_enabled(user.EMBYID, True)
-
                 await UserOperate.update_user(uid=uid, active_status=True)
+                user.ACTIVE_STATUS = True
+                if user.EMBYID:
+                    await emby.set_user_enabled(user.EMBYID, UserService.should_enable_emby_access(user))
                 success += 1
 
             except Exception as e:

--- a/src/services/scheduler_service.py
+++ b/src/services/scheduler_service.py
@@ -753,7 +753,7 @@ class SchedulerService:
 
     @staticmethod
     async def check_expired_users(ctx: RunContext):
-        """检查过期用户并禁用"""
+        """检查过期用户并禁用其 Emby 账号，保留系统账号登录能力。"""
         ctx.log("🔍 开始检查过期用户...")
         try:
             expired_users = await UserOperate.get_expired_users()
@@ -771,8 +771,6 @@ class SchedulerService:
                 try:
                     if user.EMBYID:
                         await emby.set_user_enabled(user.EMBYID, False)
-                    user.ACTIVE_STATUS = False
-                    await UserOperate.update_user(user)
                     return True, user, None
                 except Exception as e:
                     return False, user, e
@@ -786,7 +784,7 @@ class SchedulerService:
                 ok, user, err = result
                 if ok:
                     ctx.summary["disabled"] += 1
-                    ctx.log(f"  ⏹️ 已禁用: {user.USERNAME} (UID: {user.UID})")
+                    ctx.log(f"  ⏹️ 已禁用 Emby: {user.USERNAME} (UID: {user.UID})")
                 else:
                     ctx.summary["failed"] += 1
                     ctx.log(f"  ❌ 禁用失败: {user.USERNAME} - {err}")

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -58,6 +58,22 @@ class UserService:
     """用户业务服务"""
 
     @staticmethod
+    def is_emby_access_expired(user: UserModel) -> bool:
+        """Return whether the bound Emby account is past its paid expiry."""
+        if not user or not user.EMBYID:
+            return False
+        try:
+            expired_at = int(user.EXPIRED_AT or 0)
+        except (TypeError, ValueError):
+            return True
+        return expired_at > 0 and expired_at < timestamp()
+
+    @staticmethod
+    def should_enable_emby_access(user: UserModel) -> bool:
+        """Emby is enabled only when the system account is active and not expired."""
+        return bool(user and user.ACTIVE_STATUS and not UserService.is_emby_access_expired(user))
+
+    @staticmethod
     def _normalize_code_days(days: Optional[int], default: int = 30) -> int:
         """规范化卡码天数：0/-1 都视为永久（-1）。"""
         try:
@@ -816,17 +832,20 @@ class UserService:
             user.EXPIRED_AT = -1
             await UserOperate.update_user(user)
         else:
+            current_time = timestamp()
+            base_expired_at = int(user.EXPIRED_AT or 0)
+            new_expired_at = (current_time if base_expired_at < current_time else base_expired_at) + days_to_seconds(days)
             await UserOperate.renew_user_expire_time(user, days)
+            user.EXPIRED_AT = new_expired_at
 
-        # 如果用户被禁用，重新启用
+        # 如果用户被禁用，重新启用系统账号；续期后无论原本是否禁用 Emby，都按最新到期状态同步。
         if not user.ACTIVE_STATUS:
             user.ACTIVE_STATUS = True
             await UserOperate.update_user(user)
 
-            # 同时启用 Emby 账户
-            if user.EMBYID:
-                emby = get_emby_client()
-                await emby.set_user_enabled(user.EMBYID, True)
+        if user.EMBYID:
+            emby = get_emby_client()
+            await emby.set_user_enabled(user.EMBYID, UserService.should_enable_emby_access(user))
 
         logger.info(f"用户续期成功: {user.USERNAME}, days={days}")
         if days <= 0:
@@ -860,7 +879,7 @@ class UserService:
 
             if user.EMBYID:
                 emby = get_emby_client()
-                await emby.set_user_enabled(user.EMBYID, True)
+                await emby.set_user_enabled(user.EMBYID, UserService.should_enable_emby_access(user))
 
             logger.info(f"用户已启用: {user.USERNAME}")
             return True, "用户已启用"
@@ -1322,10 +1341,11 @@ class UserService:
 
         try:
             emby = get_emby_client()
-            await emby.set_user_enabled(user.EMBYID, user.ACTIVE_STATUS)
+            emby_enabled = UserService.should_enable_emby_access(user)
+            await emby.set_user_enabled(user.EMBYID, emby_enabled)
             logger.info(
                 f"用户状态已同步到 Emby: {user.USERNAME} (UID: {user.UID}), "
-                f"状态: {'启用' if user.ACTIVE_STATUS else '禁用'}"
+                f"状态: {'启用' if emby_enabled else '禁用'}"
             )
             return True, "同步成功"
         except Exception as e:
@@ -1411,8 +1431,11 @@ class UserService:
         is_pending_emby = bool(getattr(user, "PENDING_EMBY", False)) and not user.EMBYID
         # 未绑定 Emby（无 EMBYID 或处于 pending）时，覆盖默认的 expire_status 文案，
         # 避免展示"已过期"/"剩余 x"误导，同时让前端可以靠这串直接判断渲染。
+        emby_disabled_by_expiry = UserService.is_emby_access_expired(user)
         if is_pending_emby or not user.EMBYID:
             expire_status = "未绑定 Emby"
+        elif emby_disabled_by_expiry:
+            expire_status = "已到期，Emby 已禁用"
         else:
             expire_status = format_expire_time(user.EXPIRED_AT)
 
@@ -1437,6 +1460,7 @@ class UserService:
             "emby_bound": emby_bound,
             "pending_emby": is_pending_emby,
             "pending_emby_days": getattr(user, "PENDING_EMBY_DAYS", None),
+            "emby_disabled_by_expiry": emby_disabled_by_expiry,
         }
 
         return info

--- a/webui/src/app/(main)/admin/users/page.tsx
+++ b/webui/src/app/(main)/admin/users/page.tsx
@@ -79,6 +79,7 @@ export default function AdminUsersPage() {
   const [renewOpen, setRenewOpen] = useState(false);
   const [renewDays, setRenewDays] = useState("30");
   const [renewPermanent, setRenewPermanent] = useState(false);
+  const [renewMode, setRenewMode] = useState<"renew" | "cancelPermanent">("renew");
   const [selectedUser, setSelectedUser] = useState<UserInfo | null>(null);
   const [isActionLoading, setIsActionLoading] = useState(false);
   
@@ -330,9 +331,12 @@ export default function AdminUsersPage() {
 
     setIsActionLoading(true);
     try {
-      const res = await api.renewUser(selectedUser.uid, renewPermanent ? -1 : parseInt(renewDays, 10));
+      const days = renewPermanent ? -1 : parseInt(renewDays, 10);
+      const res = renewMode === "cancelPermanent"
+        ? await api.cancelUserPermanent(selectedUser.uid, days)
+        : await api.renewUser(selectedUser.uid, days);
       if (res.success) {
-        toast({ title: "续期成功", variant: "success" });
+        toast({ title: renewMode === "cancelPermanent" ? "已取消永久" : "续期成功", variant: "success" });
         setRenewOpen(false);
         setSelectedUser(null);
         invalidateUsersCache();
@@ -1155,6 +1159,7 @@ export default function AdminUsersPage() {
         <DropdownMenuItem
           onClick={() => {
             setSelectedUser(user);
+            setRenewMode("renew");
             setRenewPermanent(false);
             setRenewDays("30");
             setRenewOpen(true);
@@ -1163,6 +1168,20 @@ export default function AdminUsersPage() {
           <RefreshCw className="mr-2 h-4 w-4" />
           续期
         </DropdownMenuItem>
+        {(user.expired_at === -1 || user.expired_at === "-1") && user.role !== 0 && Boolean(user.emby_id) && (
+          <DropdownMenuItem
+            onClick={() => {
+              setSelectedUser(user);
+              setRenewMode("cancelPermanent");
+              setRenewPermanent(false);
+              setRenewDays("30");
+              setRenewOpen(true);
+            }}
+          >
+            <CalendarClock className="mr-2 h-4 w-4" />
+            取消永久到期
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onClick={() => handleResetPassword(user)}>
           <Key className="mr-2 h-4 w-4" />
           重置密码
@@ -2223,14 +2242,16 @@ export default function AdminUsersPage() {
       }}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>用户续期</DialogTitle>
+            <DialogTitle>{renewMode === "cancelPermanent" ? "取消永久有效期" : "用户续期"}</DialogTitle>
             <DialogDescription>
-              为用户 {selectedUser?.username} 延长账号时间
+              {renewMode === "cancelPermanent"
+                ? `将用户 ${selectedUser?.username} 改为指定天数后到期`
+                : `为用户 ${selectedUser?.username} 延长账号时间`}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
-              <Label>续期天数</Label>
+              <Label>{renewMode === "cancelPermanent" ? "改为多少天后到期" : "续期天数"}</Label>
               <Input
                 type="number"
                 placeholder="输入续期天数"
@@ -2239,7 +2260,7 @@ export default function AdminUsersPage() {
                 disabled={renewPermanent}
               />
             </div>
-            <label className="flex items-center gap-2 rounded-md border bg-muted/30 p-3 text-sm">
+            {renewMode !== "cancelPermanent" && <label className="flex items-center gap-2 rounded-md border bg-muted/30 p-3 text-sm">
               <input
                 type="checkbox"
                 checked={renewPermanent}
@@ -2247,7 +2268,7 @@ export default function AdminUsersPage() {
                 className="h-4 w-4"
               />
               设置为永久有效
-            </label>
+            </label>}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setRenewOpen(false)}>
@@ -2255,7 +2276,7 @@ export default function AdminUsersPage() {
             </Button>
             <Button onClick={handleRenew} disabled={isActionLoading}>
               {isActionLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              确认续期
+              {renewMode === "cancelPermanent" ? "确认取消永久" : "确认续期"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/webui/src/app/(main)/dashboard/page.tsx
+++ b/webui/src/app/(main)/dashboard/page.tsx
@@ -101,6 +101,7 @@ export default function DashboardPage() {
   const [myRequests, setMyRequests] = useState<MediaRequest[]>([]);
   const [lineSlots, setLineSlots] = useState<LineSlot[]>([]);
   const [linesRequireEmby, setLinesRequireEmby] = useState(false);
+  const [linesRequireRenewal, setLinesRequireRenewal] = useState(false);
   const [lineLatencyMap, setLineLatencyMap] = useState<Record<string, LineLatencyInfo>>({});
   const [isLatencyTesting, setIsLatencyTesting] = useState(false);
   const [signinSummary, setSigninSummary] = useState<SigninSummary | null>(null);
@@ -128,6 +129,8 @@ export default function DashboardPage() {
     lines?: Array<{ name: string; url: string }>;
     whitelist_lines?: Array<{ name: string; url: string }>;
     requires_emby_account?: boolean;
+    requires_renewal?: boolean;
+    emby_disabled_by_expiry?: boolean;
   }) => {
     const lines = (data.lines || []).map((line, index) => ({
       key: `line:${index}:${line.url}`,
@@ -143,6 +146,7 @@ export default function DashboardPage() {
     }));
     setLineSlots([...lines, ...wl]);
     setLinesRequireEmby(Boolean(data.requires_emby_account));
+    setLinesRequireRenewal(Boolean(data.requires_renewal || data.emby_disabled_by_expiry));
   }, []);
 
   const loadEmbyUrls = useCallback(async () => {
@@ -381,6 +385,7 @@ export default function DashboardPage() {
   const isPermanent = !isPendingEmby && (isAdmin || expiredTimestamp === null);
   const safeExpiredTimestamp = expiredTimestamp ?? 0;
   const isExpired = !isPermanent && !isPendingEmby && safeExpiredTimestamp < Date.now();
+  const embyDisabledByExpiry = Boolean(user?.emby_disabled_by_expiry || isExpired);
   const daysLeft = !isPermanent && !isPendingEmby
     ? Math.max(0, Math.ceil((safeExpiredTimestamp - Date.now()) / (1000 * 60 * 60 * 24)))
     : 0;
@@ -928,8 +933,21 @@ export default function DashboardPage() {
         </motion.div>
       )}
 
-      {/* 线路延迟 —— 仅在用户已绑定 Emby 时显示，避免预先泄露线路 */}
-      {!linesRequireEmby && (
+      {linesRequireRenewal || embyDisabledByExpiry ? (
+        <motion.div variants={item} className="premium-card border-destructive/30 p-5 sm:p-6">
+          <div className="flex items-start gap-3">
+            <div className="rounded-xl bg-destructive/10 p-2 text-destructive">
+              <AlertCircle className="h-5 w-5" />
+            </div>
+            <div>
+              <h3 className="text-base font-black tracking-tight">Emby 已到期</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                系统账号仍可登录查看信息，但 Emby 账号已被禁用，续期后会自动恢复线路访问。
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      ) : !linesRequireEmby && (
       <motion.div variants={item} className="premium-card p-5 sm:p-6">
         <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
           <div className="flex items-center gap-3 min-w-0">

--- a/webui/src/app/(main)/settings/page.tsx
+++ b/webui/src/app/(main)/settings/page.tsx
@@ -23,6 +23,7 @@ import {
   Globe,
   Star,
   Bot,
+  AlertCircle,
 } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -118,6 +119,7 @@ export default function SettingsPage() {
   const [embyLines, setEmbyLines] = useState<Array<{ name: string; url: string }>>([]);
   const [whitelistLines, setWhitelistLines] = useState<Array<{ name: string; url: string }>>([]);
   const [linesRequireEmby, setLinesRequireEmby] = useState(false);
+  const [linesRequireRenewal, setLinesRequireRenewal] = useState(false);
   const [copiedIndex, setCopiedIndex] = useState<string | null>(null);
   const [lineLatencyMap, setLineLatencyMap] = useState<Record<string, { status: "idle" | "testing" | "ok" | "timeout" | "error"; latencyMs?: number }>>({});
   const [isLatencyTesting, setIsLatencyTesting] = useState(false);
@@ -246,6 +248,7 @@ export default function SettingsPage() {
       setEmbyLines(res.data.lines || []);
       setWhitelistLines(res.data.whitelist_lines || []);
       setLinesRequireEmby(Boolean(res.data.requires_emby_account));
+      setLinesRequireRenewal(Boolean(res.data.requires_renewal || res.data.emby_disabled_by_expiry));
     }
   }, []);
 
@@ -928,8 +931,21 @@ export default function SettingsPage() {
         </Card>
       </motion.div>
 
-      {/* 服务器线路 —— 仅在用户已绑定 Emby 时显示，避免预先泄露线路 */}
-      {!linesRequireEmby && (
+      {linesRequireRenewal ? (
+        <motion.div variants={item}>
+          <Card className="glass-card border-destructive/30">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-destructive">
+                <AlertCircle className="h-5 w-5" />
+                Emby 已到期
+              </CardTitle>
+              <CardDescription>
+                系统账号仍可登录；Emby 已禁用，续期后恢复线路访问。
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </motion.div>
+      ) : !linesRequireEmby && (
       <motion.div variants={item}>
         <Card className="glass-card">
           <CardHeader>

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -422,6 +422,8 @@ class ApiClient {
       lines: Array<{ name: string; url: string }>;
       whitelist_lines?: Array<{ name: string; url: string }>;
       requires_emby_account?: boolean;
+      requires_renewal?: boolean;
+      emby_disabled_by_expiry?: boolean;
     }>(`/system/emby-urls`);
   }
 
@@ -771,6 +773,13 @@ class ApiClient {
 
   async renewUser(uid: number, days: number) {
     return this.request(`/admin/users/${uid}/renew`, {
+      method: "POST",
+      body: JSON.stringify({ days }),
+    });
+  }
+
+  async cancelUserPermanent(uid: number, days: number) {
+    return this.request<{ uid: number; days: number; expired_at: number; role: number; role_name: string; downgraded_whitelist: boolean }>(`/admin/users/${uid}/cancel-permanent`, {
       method: "POST",
       body: JSON.stringify({ days }),
     });
@@ -1710,6 +1719,7 @@ export interface UserInfo {
   is_pending?: boolean;  // 是否待激活
   pending_emby?: boolean;  // 系统账号已建但待补建 Emby
   pending_emby_days?: number | null;  // 注册码授予的开通天数（待 Emby 补建）
+  emby_disabled_by_expiry?: boolean;  // 到期后仅禁用 Emby，系统账号仍可登录
 }
 
 export interface ApiKeyItem {


### PR DESCRIPTION
Add explicit Emby expiry handling and an admin endpoint to cancel permanent expiry. Introduces UserService.is_emby_access_expired and UserService.should_enable_emby_access to decide Emby enablement without disabling the system account. Scheduler now only disables Emby access for expired users (keeps system login intact). Add POST /admin/users/<uid>/cancel-permanent to convert a perpetual (-1) expiry into a timed expiry with validation and optional whitelist downgrade, and sync changes to Emby with logging. Update various admin/bot handlers and batch operations to use the new enablement logic and to sync to Emby via UserService. Expose emby_disabled_by_expiry/requires_renewal flags in system API and surface warnings in dashboard/settings; add UI support in admin users page to cancel permanent expiry and corresponding API client method.