### PR TITLE
Auto-create PostgreSQL target DB on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ postgres_max_idle_conns = 4
 
 数据库恢复和迁移均需要预览与二次确认。执行前后端会创建 `pre_operation_backup`，避免误操作后没有回滚点。已有 JSON 数据切换 PostgreSQL 时，先保持 JSON 能登录，进入管理端完成 PostgreSQL 迁移预检和确认后，再重启到 PostgreSQL。旧 SQLite 管理员引导只用于恢复后台入口，不会在启动时全量迁移旧业务数据。
 
+PostgreSQL 启动时如果目标数据库不存在，后端会尝试用同一连接用户连到 `postgres` / `template1` 维护库并创建目标数据库；该用户需要 `CREATEDB` 权限。数据库创建完成后会继续初始化 `twilight_state` 状态表。
+
 ## 安全边界
 
 生产环境至少确认以下项目：

--- a/config.production.toml
+++ b/config.production.toml
@@ -51,6 +51,8 @@ tmdb_image_url = "https://image.tmdb.org/t/p"
 # 存储后端：
 #   json     = 默认 JSON 状态文件，兼容原 Go 状态存储，适合小型部署
 #   postgres = PostgreSQL 后端，适合用户量/记录量较大或需要更高并发的部署
+# 当 driver=postgres 且目标数据库不存在时，后端会尝试用同一用户连接 postgres/template1
+# 维护库并执行 CREATE DATABASE；该用户需要 CREATEDB 权限，否则会明确报错。
 driver = "json"
 # Go JSON 状态文件路径；留空时使用 <databases_dir>/twilight_go_state.json。
 state_file = ""

--- a/docs/GO_BACKEND.md
+++ b/docs/GO_BACKEND.md
@@ -117,6 +117,7 @@ Go 后端不是空接口骨架，以下模块已经按旧 Python 行为实现本
 - 现有 Go JSON 状态文件可通过 `[Database] state_file = "/path/to/twilight_go_state.json"` 或 `TWILIGHT_STATE_FILE` 指定。
 - 可选 PostgreSQL 后端：配置 `database.driver = "postgres"` 和 DSN，适合用户量、播放记录、调度记录较多的部署。
 - 生产模板 `config.production.toml` 已包含 `[Database]` 示例，可使用完整 `url` 或 `postgres_host/postgres_user/postgres_password/postgres_database` 分项配置。
+- PostgreSQL 目标数据库不存在时，启动阶段会尝试用同一连接用户连接 `postgres` / `template1` 维护库并执行 `CREATE DATABASE`；连接用户需要 `CREATEDB` 权限，已有数据库则不会重复创建。
 - 管理端提供数据库状态、备份、恢复、迁移预检和执行。
 - 恢复和迁移都必须先走预览；后端在缺少确认短语时只返回 `dry_run=true` 的预览结果，不会写入数据。
 - 迁移预检返回源/目标 driver、实体计数、快照大小、目标连通性和重启/配置告警；PostgreSQL 目标只验证连接，不创建表或写入数据。

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -71,6 +71,8 @@ TWILIGHT_POSTGRES_MAX_IDLE_CONNS=4
 
 如果只有旧 Python 版 `db/users.db`，请在 Linux 上安装 `sqlite3`。Go 后端会在自身状态没有 active 管理员时只读导入旧库 active 管理员账号；这只是登录引导，不会在启动时全量迁移旧 SQLite 业务数据。
 
+如果 PostgreSQL 用户已经存在但数据库还不存在，后端启动时会尝试自动创建 `postgres_database` / URL 中的目标数据库。该用户必须拥有 `CREATEDB` 权限；没有权限时，需要先让 PostgreSQL 管理员执行 `ALTER USER <用户名> CREATEDB;` 或手动创建数据库。
+
 ## 前端部署
 
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -107,6 +107,7 @@ cors_origins = ["https://app.example.com"]
 - 数据库备份、恢复、迁移接口均要求管理员登录；恢复目标会限制在配置的备份目录内，拒绝 `../` 路径穿越。
 - 迁移到 PostgreSQL 前先使用管理端预检，确认目标连接成功、快照大小和实体计数符合预期。
 - 切换 `database.driver` 后需要重启后端；仅迁移数据不会让当前进程自动切换已打开的 store。
+- PostgreSQL 自动建库只在目标库不存在时触发，使用配置中的同一 PostgreSQL 用户连接 `postgres` / `template1` 维护库执行 `CREATE DATABASE`；生产环境建议使用只授予当前实例所需权限的专用用户。
 - 如果 PostgreSQL 没有管理员但旧 JSON 状态里已有管理员，Go 后端会临时使用 JSON 状态启动，避免管理员在迁移前被空库锁在登录外；迁移完成并确认后再重启到 PostgreSQL。
 - 如果 Go 状态没有 active 管理员但存在旧 `db/users.db`，Go 后端会尝试通过系统 `sqlite3` 只读导入 active 管理员账号。该引导只读取固定 `users.db`，拒绝符号链接，不接受前端传入路径，不全量迁移普通用户。
 - Git 自动更新只允许 HTTPS 仓库 URL，不允许 URL 内携带用户名/密码/token。

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -15,6 +15,7 @@
 - `config.production.toml` 新增 `[Database]` PostgreSQL 配置示例，包含完整 DSN、分项连接参数、备份目录和连接池参数。
 - 新增数据库状态、备份、恢复、迁移预检和迁移执行接口，并在前端配置页提供对应入口。
 - 支持默认 JSON 状态存储和可选 PostgreSQL 存储；迁移预检会返回实体数量、快照大小、目标连通性和配置/重启告警。
+- PostgreSQL 目标数据库不存在时，启动阶段会尝试连接 `postgres` / `template1` 维护库自动执行 `CREATE DATABASE`，减少已有用户但未建库时的部署阻塞。
 - 当配置为 PostgreSQL 但目标库尚未迁移且没有管理员时，启动阶段会检测旧 JSON 状态文件；若其中已有 active 管理员，则临时回退 JSON，保证原管理员可以登录管理端执行迁移。
 - 当 Go 状态没有 active 管理员但存在旧 Python 版 `db/users.db` 时，启动阶段可通过系统 `sqlite3` 只读导入旧库 active 管理员账号用于引导登录。
 - PostgreSQL 迁移预检只做连接探测，不创建表或写入数据；实际迁移才初始化目标状态表。

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestRewritePostgresDatabaseInURLDSN(t *testing.T) {
+	got, ok := rewritePostgresDatabaseInDSN("postgres://user:pass@127.0.0.1:5432/twilight?sslmode=disable", "postgres")
+	if !ok {
+		t.Fatal("expected URL DSN to be rewritten")
+	}
+	if got != "postgres://user:pass@127.0.0.1:5432/postgres?sslmode=disable" {
+		t.Fatalf("unexpected rewritten DSN: %s", got)
+	}
+}
+
+func TestRewritePostgresDatabaseInKeywordDSN(t *testing.T) {
+	got, ok := rewritePostgresDatabaseInDSN("host=127.0.0.1 port=5432 user=twilight password=secret dbname=twilight sslmode=disable", "template1")
+	if !ok {
+		t.Fatal("expected keyword DSN to be rewritten")
+	}
+	if !strings.Contains(got, "://twilight:secret@127.0.0.1:5432/template1") || !strings.Contains(got, "sslmode=disable") {
+		t.Fatalf("unexpected rewritten keyword DSN: %s", got)
+	}
+}
+
+func TestPostgresErrorClassifiersAndIdentifierQuoting(t *testing.T) {
+	if !isUndefinedDatabaseError(&pgconn.PgError{Code: "3D000"}) {
+		t.Fatal("undefined database error was not detected")
+	}
+	if !isDuplicateDatabaseError(errors.New("ERROR: duplicate_database (SQLSTATE 42P04)")) {
+		t.Fatal("duplicate database error was not detected")
+	}
+	if got := quotePostgresIdentifier(`twilight"prod`); got != `"twilight""prod"` {
+		t.Fatalf("identifier was not quoted safely: %s", got)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
@@ -334,7 +337,24 @@ func OpenPostgres(ctx context.Context, dsn string) (*Store, error) {
 	db.SetConnMaxLifetime(30 * time.Minute)
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
-		return nil, err
+		if isUndefinedDatabaseError(err) {
+			if createErr := CreatePostgresDatabase(ctx, dsn); createErr != nil {
+				return nil, fmt.Errorf("postgres database does not exist and automatic creation failed: %w", createErr)
+			}
+			db, err = sql.Open("pgx", dsn)
+			if err != nil {
+				return nil, err
+			}
+			db.SetMaxOpenConns(8)
+			db.SetMaxIdleConns(4)
+			db.SetConnMaxLifetime(30 * time.Minute)
+			if err := db.PingContext(ctx); err != nil {
+				_ = db.Close()
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 	if _, err := db.ExecContext(ctx, `
 CREATE TABLE IF NOT EXISTS twilight_state (
@@ -364,6 +384,115 @@ CREATE TABLE IF NOT EXISTS twilight_state (
 	}
 	st.state.ensure()
 	return st, nil
+}
+
+func CreatePostgresDatabase(ctx context.Context, dsn string) error {
+	cfg, err := pgconn.ParseConfig(strings.TrimSpace(dsn))
+	if err != nil {
+		return err
+	}
+	target := strings.TrimSpace(cfg.Database)
+	if target == "" {
+		return fmt.Errorf("target database name is empty")
+	}
+	if strings.EqualFold(target, "postgres") || strings.EqualFold(target, "template1") {
+		return fmt.Errorf("refusing to auto-create maintenance database %q", target)
+	}
+	maintenanceDSNs := maintenancePostgresDSNs(dsn)
+	var lastErr error
+	for _, maintenanceDSN := range maintenanceDSNs {
+		db, err := sql.Open("pgx", maintenanceDSN)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(0)
+		_, err = db.ExecContext(ctx, `CREATE DATABASE `+quotePostgresIdentifier(target))
+		closeErr := db.Close()
+		if err == nil && closeErr == nil {
+			return nil
+		}
+		if err == nil {
+			err = closeErr
+		}
+		if isDuplicateDatabaseError(err) {
+			return nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no maintenance database connection strings could be built")
+	}
+	return lastErr
+}
+
+func maintenancePostgresDSNs(dsn string) []string {
+	databases := []string{"postgres", "template1"}
+	out := make([]string, 0, len(databases))
+	for _, database := range databases {
+		if rewritten, ok := rewritePostgresDatabaseInDSN(dsn, database); ok {
+			out = append(out, rewritten)
+		}
+	}
+	return out
+}
+
+func rewritePostgresDatabaseInDSN(dsn, database string) (string, bool) {
+	dsn = strings.TrimSpace(dsn)
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		parsed, err := url.Parse(dsn)
+		if err != nil {
+			return "", false
+		}
+		parsed.Path = "/" + database
+		return parsed.String(), true
+	}
+	cfg, err := pgconn.ParseConfig(dsn)
+	if err != nil || cfg.Host == "" || cfg.User == "" {
+		return "", false
+	}
+	u := url.URL{
+		Scheme: "postgres",
+		Host:   net.JoinHostPort(cfg.Host, strconv.Itoa(int(cfg.Port))),
+		Path:   "/" + database,
+	}
+	if cfg.Password == "" {
+		u.User = url.User(cfg.User)
+	} else {
+		u.User = url.UserPassword(cfg.User, cfg.Password)
+	}
+	q := u.Query()
+	if cfg.TLSConfig == nil {
+		q.Set("sslmode", "disable")
+	}
+	for key, value := range cfg.RuntimeParams {
+		if strings.TrimSpace(value) != "" {
+			q.Set(key, value)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), true
+}
+
+func isUndefinedDatabaseError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "3D000" {
+		return true
+	}
+	return strings.Contains(err.Error(), "SQLSTATE 3D000")
+}
+
+func isDuplicateDatabaseError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "42P04" {
+		return true
+	}
+	return strings.Contains(err.Error(), "SQLSTATE 42P04")
+}
+
+func quotePostgresIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }
 
 func CheckPostgres(ctx context.Context, dsn string) error {


### PR DESCRIPTION
Attempt to automatically create the configured PostgreSQL database when the target DB does not exist during startup. Implements CreatePostgresDatabase and helpers to rewrite DSNs to maintenance DBs (postgres/template1), detect undefined/duplicate-database errors, and safely quote identifiers. OpenPostgres now retries after auto-creation; duplicate-database errors are treated as success. Adds unit tests (internal/store/postgres_test.go) and updates README, config.production.toml and docs (GO_BACKEND, INSTALL, SECURITY, VERSION_HISTORY) to document the behavior and required CREATEDB permission.