### PR TITLE
Pass error object to PageError component

### DIFF
--- a/webui/src/app/(main)/admin/violations/page.tsx
+++ b/webui/src/app/(main)/admin/violations/page.tsx
@@ -116,7 +116,7 @@ export default function AdminViolationsPage() {
 
   const totalPages = Math.ceil(total / 20);
 
-  if (error) return <PageError message={error.message} />;
+  if (error) return <PageError message={error} />;
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
Update AdminViolationsPage to pass the full error object to PageError (message={error}) instead of only error.message. This lets the PageError component access additional error properties (e.g. stack) and handle non-string errors more consistently.