### PR TITLE
TOML parsing, Emby checks, add violations nav

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -676,10 +676,16 @@ func (a *App) handleLibraries(w http.ResponseWriter, r *http.Request, params Par
 	if strings.Contains(r.URL.Path, "/emby/libraries") || strings.Contains(r.URL.Path, "/admin/emby/libraries") {
 		remoteLibraries, err := a.embyLibraries(r.Context())
 		if err != nil {
-			fail(w, http.StatusBadGateway, "failed to read Emby libraries")
+			fail(w, http.StatusBadGateway, "无法连接 Emby 服务器，请检查 Emby 是否在线："+err.Error())
 			return
 		}
 		ok(w, "OK", remoteLibraries)
+		return
+	}
+
+	// Pre-check: Emby must be configured
+	if a.cfg.EmbyURL == "" {
+		fail(w, http.StatusServiceUnavailable, "Emby 未配置")
 		return
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -539,7 +539,48 @@ func readTOML(path string, values map[string]string) error {
 }
 
 func normalizeValue(value string) string {
-	return strings.TrimSpace(strings.Trim(strings.TrimSpace(value), "\"'"))
+	value = strings.TrimSpace(value)
+	// Strip outer quotes and unescape TOML string escape sequences
+	if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) ||
+		(strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {
+		value = value[1 : len(value)-1]
+	}
+	return unescapeTomlString(value)
+}
+
+// unescapeTomlString handles common TOML escape sequences within string values.
+func unescapeTomlString(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case '"':
+				b.WriteByte('"')
+				i++
+			case '\\':
+				b.WriteByte('\\')
+				i++
+			case 'n':
+				b.WriteByte('\n')
+				i++
+			case 't':
+				b.WriteByte('\t')
+				i++
+			case 'r':
+				b.WriteByte('\r')
+				i++
+			default:
+				b.WriteByte(s[i])
+			}
+		} else {
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
 }
 
 func bracketDelta(line string) int {
@@ -638,15 +679,60 @@ func listValue(value string) []string {
 	if value == "" {
 		return nil
 	}
-	parts := strings.Split(value, ",")
+	parts := splitRespectingQuotes(value)
 	out := make([]string, 0, len(parts))
 	for _, part := range parts {
-		part = strings.TrimSpace(strings.Trim(part, "\"'"))
+		part = strings.TrimSpace(part)
+		// Strip surrounding quotes and unescape
+		if (strings.HasPrefix(part, "\"") && strings.HasSuffix(part, "\"")) ||
+			(strings.HasPrefix(part, "'") && strings.HasSuffix(part, "'")) {
+			part = unescapeTomlString(part[1 : len(part)-1])
+		}
 		if part != "" {
 			out = append(out, part)
 		}
 	}
 	return out
+}
+
+// splitRespectingQuotes splits a string by commas but respects quoted segments.
+func splitRespectingQuotes(s string) []string {
+	var parts []string
+	var current strings.Builder
+	inQuote := rune(0)
+	escaped := false
+	for _, r := range s {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' && inQuote == '"' {
+			current.WriteRune(r)
+			escaped = true
+			continue
+		}
+		if (r == '"' || r == '\'') && inQuote == 0 {
+			inQuote = r
+			current.WriteRune(r)
+			continue
+		}
+		if r == inQuote {
+			inQuote = 0
+			current.WriteRune(r)
+			continue
+		}
+		if r == ',' && inQuote == 0 {
+			parts = append(parts, current.String())
+			current.Reset()
+			continue
+		}
+		current.WriteRune(r)
+	}
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	return parts
 }
 
 func int64ListValue(value string) []int64 {

--- a/webui/src/components/layout/sidebar.tsx
+++ b/webui/src/components/layout/sidebar.tsx
@@ -30,6 +30,7 @@ import {
   Coins,
   Github,
   ScrollText,
+  ShieldAlert,
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
@@ -80,6 +81,7 @@ export const adminNavItems: SidebarNavItem[] = [
   { href: "/admin/regcodes", label: "注册码", icon: FileText },
   { href: "/admin/invite", label: "邀请森林", icon: Network },
   { href: "/admin/requests", label: "求片审核", icon: Film },
+  { href: "/admin/violations", label: "违规审计", icon: ShieldAlert },
   { href: "/admin/telegram-rebind-requests", label: "Telegram 换绑", icon: MessageSquare },
   { href: "/admin/emby", label: "Emby 管理", icon: Server },
   { href: "/admin/scheduler", label: "定时任务", icon: TimerReset },


### PR DESCRIPTION
Improve TOML config handling by trimming outer quotes, unescaping common TOML escape sequences, and splitting lists by commas while respecting quoted segments (splitRespectingQuotes, unescapeTomlString). Update listValue to unescape quoted items. Add a pre-check in the Emby libraries handler to return 503 if Emby is not configured and provide a clearer error when Emby is unreachable. Add a "违规审计" (violations) admin navigation item to the web UI sidebar.