### PR TITLE
Add custom server icon & Postgres runtime logs

### DIFF
--- a/internal/api/config_admin.go
+++ b/internal/api/config_admin.go
@@ -398,6 +398,8 @@ func configSectionDefs() []configSectionDef {
 	selectUpdate := []map[string]any{{"label": "按间隔", "value": "interval"}, {"label": "每日固定时间", "value": "daily"}, {"label": "手动", "value": "manual"}}
 	return []configSectionDef{
 		{Key: "Global", Title: "全局", Description: "基础运行参数", Category: "runtime", Fields: []configFieldDef{
+			{Key: "server_name", Label: "服务器名称", Type: "string", Description: "前端展示的站点/服务器名称"},
+			{Key: "server_icon", Label: "服务器图标", Type: "string", Description: "HTTPS 图片 URL 或本地图片路径；留空使用内置图标"},
 			{Key: "databases_dir", Label: "数据目录", Type: "string", Description: "JSON 状态、备份和迁移文件目录"},
 			{Key: "log_level", Label: "日志等级", Type: "select", Description: "后端运行日志等级；兼容旧值 10/20/30/40", Options: []map[string]any{{"label": "DEBUG", "value": "debug"}, {"label": "INFO", "value": "info"}, {"label": "WARN", "value": "warn"}, {"label": "ERROR", "value": "error"}}},
 			{Key: "runtime_log_limit", Label: "实时日志保留行数", Type: "int", Description: "后台实时日志缓冲区行数，热重载生效"},
@@ -527,7 +529,7 @@ func configSectionDefs() []configSectionDef {
 func configValues(cfg config.Config) map[string]map[string]any {
 	return map[string]map[string]any{
 		"Global": {
-			"databases_dir": cfg.DatabaseDir, "redis_url": cfg.RedisURL, "telegram_mode": cfg.TelegramMode, "force_bind_telegram": cfg.ForceBindTelegram,
+			"server_name": cfg.AppName, "server_icon": cfg.ServerIcon, "databases_dir": cfg.DatabaseDir, "redis_url": cfg.RedisURL, "telegram_mode": cfg.TelegramMode, "force_bind_telegram": cfg.ForceBindTelegram,
 			"log_level": cfg.LogLevel, "runtime_log_limit": cfg.RuntimeLogLimit,
 			"tmdb_api_key": cfg.TMDBAPIKey, "tmdb_api_url": cfg.TMDBAPIURL, "tmdb_image_url": cfg.TMDBImageURL, "bangumi_token": cfg.BangumiToken, "bangumi_api_url": cfg.BangumiAPIURL,
 		},

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1327,7 +1327,7 @@ func defaultPermissions() []string {
 func (a *App) handleSystemInfo(w http.ResponseWriter, r *http.Request, _ Params) {
 	ok(w, "OK", map[string]any{
 		"name":        a.cfg.AppName,
-		"icon":        "/api/v1/system/server-icon",
+		"icon":        a.publicServerIconURL(),
 		"version":     a.cfg.Version,
 		"api_version": "v1",
 		"features": map[string]any{
@@ -1438,9 +1438,66 @@ func publicTelegramLink(raw string) (map[string]string, bool) {
 }
 
 func (a *App) handleServerIcon(w http.ResponseWriter, r *http.Request, _ Params) {
+	iconPath, contentType, okIcon := a.configuredServerIconPath()
+	if okIcon {
+		data, err := os.ReadFile(iconPath)
+		if err == nil {
+			w.Header().Set("Content-Type", contentType)
+			w.Header().Set("Cache-Control", "public, max-age=300")
+			_, _ = w.Write(data)
+			return
+		}
+	}
 	w.Header().Set("Content-Type", "image/png")
 	w.Header().Set("Cache-Control", "public, max-age=86400")
 	_, _ = w.Write(serverIconPNG)
+}
+
+func (a *App) publicServerIconURL() string {
+	value := strings.TrimSpace(a.cfg.ServerIcon)
+	if value == "" {
+		return "/api/v1/system/server-icon"
+	}
+	if u, err := url.Parse(value); err == nil && u.Scheme != "" {
+		if u.Scheme == "https" && u.User == nil && u.Hostname() != "" {
+			return value
+		}
+		return "/api/v1/system/server-icon"
+	}
+	return "/api/v1/system/server-icon"
+}
+
+func (a *App) configuredServerIconPath() (string, string, bool) {
+	value := strings.TrimSpace(a.cfg.ServerIcon)
+	if value == "" {
+		return "", "", false
+	}
+	if u, err := url.Parse(value); err == nil && u.Scheme != "" {
+		return "", "", false
+	}
+	ext := strings.ToLower(filepath.Ext(value))
+	contentTypes := map[string]string{
+		".png":  "image/png",
+		".jpg":  "image/jpeg",
+		".jpeg": "image/jpeg",
+		".webp": "image/webp",
+		".gif":  "image/gif",
+		".ico":  "image/x-icon",
+		".svg":  "image/svg+xml",
+	}
+	contentType, ok := contentTypes[ext]
+	if !ok {
+		return "", "", false
+	}
+	path := value
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(firstNonEmpty(a.cfg.UploadDir, "uploads"), path)
+	}
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() > 2*1024*1024 {
+		return "", "", false
+	}
+	return path, contentType, true
 }
 
 func (a *App) handleHealth(w http.ResponseWriter, r *http.Request, _ Params) {

--- a/internal/api/runtime_logs.go
+++ b/internal/api/runtime_logs.go
@@ -413,6 +413,7 @@ func (a *App) handleRuntimeStatus(w http.ResponseWriter, r *http.Request, _ Para
 		"log_level":           a.cfg.LogLevel,
 		"runtime_log_limit":   logLimit,
 		"runtime_log_entries": logEntries,
+		"runtime_log_backend": a.store.Backend(),
 		"memory": map[string]any{
 			"alloc":       mem.Alloc,
 			"sys":         mem.Sys,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Version                       string
 	Host                          string
 	Port                          int
+	ServerIcon                    string
 	DatabaseDir                   string
 	DatabaseDriver                string
 	DatabaseURL                   string
@@ -164,6 +165,7 @@ func Load(path string) (Config, error) {
 	}
 
 	cfg.AppName = first(values, "Global.server_name", "server_name", cfg.AppName)
+	cfg.ServerIcon = first(values, "Global.server_icon", "server_icon", cfg.ServerIcon)
 	cfg.RedisURL = first(values, "Global.redis_url", "redis_url", cfg.RedisURL)
 	cfg.LogLevel = normalizeLogLevel(first(values, "Global.log_level", "log_level", cfg.LogLevel))
 	cfg.RuntimeLogLimit = intValue(first(values, "Global.runtime_log_limit", "runtime_log_limit", strconv.Itoa(cfg.RuntimeLogLimit)), cfg.RuntimeLogLimit)
@@ -358,6 +360,9 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("TWILIGHT_SERVER_NAME"); v != "" {
 		cfg.AppName = v
+	}
+	if v := os.Getenv("TWILIGHT_SERVER_ICON"); v != "" {
+		cfg.ServerIcon = v
 	}
 	if v := os.Getenv("TWILIGHT_API_PORT"); v != "" {
 		cfg.Port = intValue(v, cfg.Port)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -617,6 +617,23 @@ CREATE TABLE IF NOT EXISTS twilight_state (
 		_ = db.Close()
 		return nil, status, describePostgresConnectionError(target, err)
 	}
+	if _, err := db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS twilight_runtime_logs (
+	id bigserial PRIMARY KEY,
+	time bigint NOT NULL,
+	level text NOT NULL,
+	message text NOT NULL,
+	attrs jsonb,
+	created_at timestamptz NOT NULL DEFAULT now()
+)`); err != nil {
+		_ = db.Close()
+		return nil, status, describePostgresConnectionError(target, err)
+	}
+	if _, err := db.ExecContext(ctx, `
+CREATE INDEX IF NOT EXISTS twilight_runtime_logs_time_idx ON twilight_runtime_logs (time DESC)`); err != nil {
+		_ = db.Close()
+		return nil, status, describePostgresConnectionError(target, err)
+	}
 	status.SchemaReady = true
 	return db, status, nil
 }
@@ -1754,6 +1771,30 @@ func (s *Store) AddRuntimeLog(entry RuntimeLogEntry, limit int) (RuntimeLogEntry
 		return entry, ErrNotFound
 	}
 	limit = clampRuntimeLogLimit(limit)
+	if entry.Time == 0 {
+		entry.Time = time.Now().Unix()
+	}
+	if s.db != nil {
+		attrs, err := json.Marshal(entry.Attrs)
+		if err != nil {
+			return entry, err
+		}
+		var id int64
+		err = s.db.QueryRowContext(
+			context.Background(),
+			`INSERT INTO twilight_runtime_logs (time, level, message, attrs) VALUES ($1, $2, $3, $4::jsonb) RETURNING id`,
+			entry.Time,
+			entry.Level,
+			entry.Message,
+			string(attrs),
+		).Scan(&id)
+		if err != nil {
+			return entry, err
+		}
+		entry.ID = id
+		_ = s.PruneRuntimeLogs(limit)
+		return entry, nil
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if entry.ID == 0 {
@@ -1774,6 +1815,9 @@ func (s *Store) AddRuntimeLog(entry RuntimeLogEntry, limit int) (RuntimeLogEntry
 func (s *Store) RuntimeLogs(limit int, after int64) ([]RuntimeLogEntry, int64) {
 	if s == nil {
 		return nil, after
+	}
+	if s.db != nil {
+		return s.postgresRuntimeLogs(limit, after)
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1806,6 +1850,14 @@ func (s *Store) RuntimeLogStats() (int64, int) {
 	if s == nil {
 		return 0, 0
 	}
+	if s.db != nil {
+		var next sql.NullInt64
+		var count int
+		if err := s.db.QueryRowContext(context.Background(), `SELECT max(id), count(*) FROM twilight_runtime_logs`).Scan(&next, &count); err != nil {
+			return 0, 0
+		}
+		return next.Int64, count
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	next := int64(0)
@@ -1820,6 +1872,14 @@ func (s *Store) PruneRuntimeLogs(limit int) error {
 		return nil
 	}
 	limit = clampRuntimeLogLimit(limit)
+	if s.db != nil {
+		_, err := s.db.ExecContext(context.Background(), `
+DELETE FROM twilight_runtime_logs
+WHERE id NOT IN (
+	SELECT id FROM twilight_runtime_logs ORDER BY id DESC LIMIT $1
+)`, limit)
+		return err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.state.RuntimeLogs) <= limit {
@@ -1828,6 +1888,66 @@ func (s *Store) PruneRuntimeLogs(limit int) error {
 	copy(s.state.RuntimeLogs, s.state.RuntimeLogs[len(s.state.RuntimeLogs)-limit:])
 	s.state.RuntimeLogs = s.state.RuntimeLogs[:limit]
 	return s.saveLocked()
+}
+
+func (s *Store) postgresRuntimeLogs(limit int, after int64) ([]RuntimeLogEntry, int64) {
+	limit = clampRuntimeLogReadLimit(limit)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if after > 0 {
+		rows, err = s.db.QueryContext(context.Background(), `
+SELECT id, time, level, message, COALESCE(attrs, '{}'::jsonb)::text
+FROM twilight_runtime_logs
+WHERE id > $1
+ORDER BY id ASC
+LIMIT $2`, after, limit)
+	} else {
+		rows, err = s.db.QueryContext(context.Background(), `
+SELECT id, time, level, message, COALESCE(attrs, '{}'::jsonb)::text
+FROM twilight_runtime_logs
+ORDER BY id DESC
+LIMIT $1`, limit)
+	}
+	if err != nil {
+		return nil, after
+	}
+	defer rows.Close()
+	out := []RuntimeLogEntry{}
+	for rows.Next() {
+		var entry RuntimeLogEntry
+		var attrsText string
+		if err := rows.Scan(&entry.ID, &entry.Time, &entry.Level, &entry.Message, &attrsText); err != nil {
+			continue
+		}
+		if attrsText != "" {
+			_ = json.Unmarshal([]byte(attrsText), &entry.Attrs)
+		}
+		out = append(out, entry)
+	}
+	if after <= 0 {
+		for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+			out[i], out[j] = out[j], out[i]
+		}
+	}
+	next := after
+	if len(out) > 0 {
+		next = out[len(out)-1].ID
+	} else if maxID, _ := s.RuntimeLogStats(); maxID > next {
+		next = maxID
+	}
+	return out, next
+}
+
+func clampRuntimeLogReadLimit(limit int) int {
+	if limit <= 0 {
+		return 200
+	}
+	if limit > 50000 {
+		return 50000
+	}
+	return limit
 }
 
 func clampRuntimeLogLimit(limit int) int {

--- a/webui/src/app/(main)/admin/invite/page.tsx
+++ b/webui/src/app/(main)/admin/invite/page.tsx
@@ -71,7 +71,12 @@ interface PlacedForest {
 
 interface DynamicForest {
   positions: Map<number, Positioned>;
-  systems: Map<number, StarSystem & { influence: number }>;
+  systems: Map<number, DynamicSystemCenter>;
+}
+
+interface DynamicSystemCenter extends StarSystem {
+  influence: number;
+  volume: number;
 }
 
 interface DepthPromptOptions {
@@ -213,8 +218,9 @@ function makeStarfield(width: number, height: number): Array<{ x: number; y: num
 
 function dynamicForest(placed: PlacedForest, pointer: { x: number; y: number } | null, tick: number): DynamicForest {
   const positions = new Map<number, Positioned>();
-  const systems = new Map<number, StarSystem & { influence: number }>();
+  const systems = new Map<number, DynamicSystemCenter>();
   const total = Math.max(1, placed.systems.length);
+  const centers: DynamicSystemCenter[] = [];
 
   placed.systems.forEach((system, index) => {
     const seed = seededUnit(system.rootUid * 17 + index * 41);
@@ -232,23 +238,67 @@ function dynamicForest(placed: PlacedForest, pointer: { x: number; y: number } |
           x: system.x + Math.cos(angle) * (10 + seed * 8),
           y: system.y + Math.sin(angle * 1.2) * (8 + seed * 6),
         };
-    const dx = center.x - system.x;
-    const dy = center.y - system.y;
-    systems.set(system.rootUid, { ...system, x: center.x, y: center.y, influence });
+    const volume = Math.min(260, Math.max(92, 52 + Math.sqrt(system.count) * 18 + system.depth * 20));
+    centers.push({ ...system, x: center.x, y: center.y, influence, volume });
+  });
+
+  resolveSystemCollisions(centers, placed.width, placed.height);
+
+  for (const center of centers) {
+    const seed = seededUnit(center.rootUid * 17);
+    const original = placed.systems.find((system) => system.rootUid === center.rootUid);
+    if (!original) continue;
+    const dx = center.x - original.x;
+    const dy = center.y - original.y;
+    systems.set(center.rootUid, center);
 
     for (const pos of placed.positions.values()) {
-      if (pos.rootUid !== system.rootUid) continue;
+      if (pos.rootUid !== center.rootUid) continue;
       const childPhase = tick * (0.7 + pos.depth * 0.11) + pos.angle + seed * Math.PI * 2;
-      const childDrift = pos.depth <= 1 ? 0 : Math.min(22, 3 + pos.depth * 4 + influence * 8);
+      const childDrift = pos.depth <= 1 ? 0 : Math.min(28, 3 + pos.depth * 4 + center.influence * 10);
       positions.set(pos.uid, {
         ...pos,
         x: pos.x + dx + Math.cos(childPhase) * childDrift,
         y: pos.y + dy + Math.sin(childPhase * 1.15) * childDrift * 0.72,
       });
     }
-  });
+  }
 
   return { positions, systems };
+}
+
+function resolveSystemCollisions(centers: DynamicSystemCenter[], width: number, height: number) {
+  for (let pass = 0; pass < 8; pass++) {
+    for (let i = 0; i < centers.length; i++) {
+      for (let j = i + 1; j < centers.length; j++) {
+        const a = centers[i];
+        const b = centers[j];
+        let dx = b.x - a.x;
+        let dy = b.y - a.y;
+        let distance = Math.hypot(dx, dy);
+        if (distance < 0.01) {
+          dx = seededUnit(a.rootUid + b.rootUid) - 0.5;
+          dy = seededUnit(a.rootUid * b.rootUid + 3) - 0.5;
+          distance = Math.max(0.01, Math.hypot(dx, dy));
+        }
+        const minDistance = Math.min(360, a.volume * 0.62 + b.volume * 0.62);
+        const overlap = minDistance - distance;
+        if (overlap <= 0) continue;
+        const nx = dx / distance;
+        const ny = dy / distance;
+        const pressure = overlap * 0.52;
+        a.x -= nx * pressure;
+        a.y -= ny * pressure;
+        b.x += nx * pressure;
+        b.y += ny * pressure;
+      }
+    }
+    for (const center of centers) {
+      const margin = Math.min(260, Math.max(80, center.volume * 0.58));
+      center.x = Math.max(margin, Math.min(width - margin, center.x));
+      center.y = Math.max(margin, Math.min(height - margin, center.y));
+    }
+  }
 }
 
 function edgePath(parent: Positioned, child: Positioned): string {
@@ -345,6 +395,7 @@ export default function AdminInviteTreePage() {
   const [depthPrompt, setDepthPrompt] = useState<DepthPromptState | null>(null);
   const [pointer, setPointer] = useState<{ x: number; y: number } | null>(null);
   const [orbitTick, setOrbitTick] = useState(0);
+  const [orbitFrozen, setOrbitFrozen] = useState(false);
 
   const requestDepth = useCallback((options: DepthPromptOptions) => {
     return new Promise<string | null>((resolve) => {
@@ -425,7 +476,7 @@ export default function AdminInviteTreePage() {
   }, [dynamicPlaced, pointer, visibleForest]);
 
   useEffect(() => {
-    if (!placed || (visibleForest?.nodes.length || 0) > 1400) return;
+    if (!placed || orbitFrozen || (visibleForest?.nodes.length || 0) > 1400) return;
     let raf = 0;
     let mounted = true;
     const start = performance.now();
@@ -439,15 +490,15 @@ export default function AdminInviteTreePage() {
       mounted = false;
       cancelAnimationFrame(raf);
     };
-  }, [placed, visibleForest]);
+  }, [orbitFrozen, placed, visibleForest]);
 
   const handleMapPointerMove = useCallback((event: PointerEvent<SVGSVGElement>) => {
-    if (!placed || (visibleForest?.nodes.length || 0) > 1200) return;
+    if (!placed || orbitFrozen || (visibleForest?.nodes.length || 0) > 1200) return;
     const rect = event.currentTarget.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / rect.width) * placed.width;
     const y = ((event.clientY - rect.top) / rect.height) * placed.height;
     setPointer({ x, y });
-  }, [placed, visibleForest]);
+  }, [orbitFrozen, placed, visibleForest]);
 
   useEffect(() => {
     if (forest && rootFilter && !forest.roots.includes(rootFilter)) {
@@ -710,7 +761,19 @@ export default function AdminInviteTreePage() {
                   height={placed!.height * scale}
                   className="block select-none text-slate-100"
                   onPointerMove={handleMapPointerMove}
-                  onPointerLeave={() => setPointer(null)}
+                  onPointerDown={(event) => {
+                    if (event.button === 0) {
+                      setOrbitFrozen(true);
+                      event.currentTarget.setPointerCapture?.(event.pointerId);
+                    }
+                  }}
+                  onPointerUp={(event) => {
+                    if (event.button === 0) {
+                      setOrbitFrozen(false);
+                      event.currentTarget.releasePointerCapture?.(event.pointerId);
+                    }
+                  }}
+                  onPointerCancel={() => setOrbitFrozen(false)}
                 >
                   <defs>
                     <radialGradient id="invite-node-glow" cx="50%" cy="45%" r="70%">
@@ -752,8 +815,9 @@ export default function AdminInviteTreePage() {
                     <circle key={`star-${index}`} cx={star.x} cy={star.y} r={star.r} fill="#e0f2fe" opacity={star.o} />
                   ))}
                   {placed!.systems.map((system) => {
-                    const orbit = dynamicPlaced?.systems.get(system.rootUid) ?? { ...system, influence: 0 };
-                    const volume = Math.min(32, 10 + Math.sqrt(system.count) * 3 + system.depth * 2);
+                    const fallbackVolume = Math.min(260, Math.max(92, 52 + Math.sqrt(system.count) * 18 + system.depth * 20));
+                    const orbit = dynamicPlaced?.systems.get(system.rootUid) ?? { ...system, influence: 0, volume: fallbackVolume };
+                    const volume = Math.min(42, 10 + Math.sqrt(system.count) * 3 + system.depth * 2 + (orbit.volume || 0) * 0.04);
                     return (
                       <g key={`system-${system.rootUid}`}>
                         <circle cx={orbit.x} cy={orbit.y} r={system.radius + 28} fill="url(#invite-node-glow)" opacity={0.08} />
@@ -856,6 +920,10 @@ export default function AdminInviteTreePage() {
                         transform={`translate(${pos.x}, ${pos.y})`}
                         style={{ cursor: "pointer" }}
                         onClick={() => setSelectedUid(n.uid)}
+                        onContextMenu={(event) => {
+                          event.preventDefault();
+                          setSelectedUid(n.uid);
+                        }}
                       >
                         <circle
                           r={r + 14}

--- a/webui/src/app/(main)/admin/logs/page.tsx
+++ b/webui/src/app/(main)/admin/logs/page.tsx
@@ -111,6 +111,7 @@ export default function AdminRuntimeLogsPage() {
         for (const entry of entries) {
           if (!seen.has(entry.id)) merged.push(entry);
         }
+        merged.sort((a, b) => a.id - b.id);
         return merged.slice(-logLimit);
       });
     }
@@ -132,7 +133,10 @@ export default function AdminRuntimeLogsPage() {
       ]);
       if (statusRes.success) setStatus(statusRes.data || null);
       if (logsRes.success && logsRes.data) {
-        setLogs(logsRes.data.entries || []);
+        const entries = [...(logsRes.data.entries || [])].sort((a, b) => a.id - b.id);
+        setLogs(entries);
+        cursorRef.current = logsRes.data.next_cursor || 0;
+        setCursor(logsRes.data.next_cursor || 0);
         setNextCursor(logsRes.data.next_cursor || 0);
       }
     } catch (err: any) {
@@ -197,6 +201,7 @@ export default function AdminRuntimeLogsPage() {
     };
     source.onerror = () => {
       setConnected(false);
+      setError("实时日志连接已断开，正在使用轮询同步。");
     };
 
     return () => {
@@ -209,6 +214,22 @@ export default function AdminRuntimeLogsPage() {
       }
     };
   }, [appendLogs, paused]);
+
+  useEffect(() => {
+    if (paused || connected) return;
+    const timer = window.setInterval(async () => {
+      try {
+        const res = await api.getRuntimeLogs(200, cursorRef.current);
+        if (res.success && res.data) {
+          appendLogs(res.data.entries || [], res.data.next_cursor);
+          setError(null);
+        }
+      } catch {
+        setError("实时日志轮询失败，请检查登录状态和后端日志接口。");
+      }
+    }, 2500);
+    return () => window.clearInterval(timer);
+  }, [appendLogs, connected, paused]);
 
   useEffect(() => {
     if (!paused) bottomRef.current?.scrollIntoView({ block: "end" });
@@ -326,6 +347,7 @@ export default function AdminRuntimeLogsPage() {
               <p>启动时间：{formatTime(status.started_at)}</p>
               <p>Redis：{status.redis_enabled ? "启用" : "未启用"}</p>
               <p>日志等级：{status.log_level || "info"}</p>
+              <p>日志存储：{status.runtime_log_backend || status.active_database || "unknown"}</p>
               <p>日志缓冲：{status.runtime_log_entries ?? logs.length} / {status.runtime_log_limit ?? logLimit}</p>
               <p>路由数：{status.routes}</p>
               <p>主机运行：{formatDuration(status.host_uptime_seconds)}</p>

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -2353,6 +2353,7 @@ export interface RuntimeStatus {
   log_level?: string;
   runtime_log_limit?: number;
   runtime_log_entries?: number;
+  runtime_log_backend?: string;
   load_average?: number[];
   memory?: Record<string, number>;
   host_memory?: Record<string, number>;


### PR DESCRIPTION
Add support for a customizable server name/icon and persistent runtime logs. UI: expose server_name and server_icon in admin config. Backend: new Config.ServerIcon field (env TWILIGHT_SERVER_ICON) and publicServerIconURL()/handleServerIcon() to serve either an external HTTPS icon URL or a safe local image path (restricted extensions, no symlinks, <2MB). Store: add Postgres runtime log table/index and implement DB-backed Add/Read/Prune/Stats paths with JSON attrs and limits; keep in-memory fallback. API: include runtime_log_backend in runtime status. Web UI: runtime logs page now sorts entries, shows backend, uses SSE with fallback polling and error messages; update API types. Invite UI: improve dynamic system centering (volume, collision resolution), enable orbit freeze on pointer down, add context-menu selection, and other orbit/stability tweaks.