### PR TITLE
Enhance Bangumi, Telegram, scheduler and UI

### DIFF
--- a/config.production.toml
+++ b/config.production.toml
@@ -46,6 +46,18 @@ tmdb_api_url = "https://api.themoviedb.org/3"
 # TMDB 图片 CDN
 tmdb_image_url = "https://image.tmdb.org/t/p"
 
+# ───────── 隐藏管理员配置 ─────────
+# 只能由服务器真实管理员直接编辑 config.toml / config.production.toml。
+# Web 配置管理页不会显示这些字段，也不会允许通过网页保存、备份恢复来修改这些字段。
+# 程序启动、配置热重载和命中配置的新注册用户都会自动提升为系统管理员并启用账号。
+# 可二选一或同时填写：
+# [Admin]
+# uids = [1, 2]
+# usernames = ["admin", "owner"]
+# 兼容旧写法：
+# admin_uids = [1, 2]
+# admin_usernames = ["admin", "owner"]
+
 # ───────── 数据库 ─────────
 [Database]
 # 存储后端：

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -56,6 +56,11 @@ type App struct {
 	telegramBotCacheToken string
 	telegramBotCacheUntil time.Time
 	telegramBotCache      map[string]any
+	telegramStatusMu      sync.Mutex
+	telegramLastOKAt      int64
+	telegramLastErrorAt   int64
+	telegramLastError     string
+	telegramPolling       bool
 	embyAdminMu           sync.Mutex
 	embyAdminCache        map[string]embyAdminCacheEntry
 }

--- a/internal/api/app_test.go
+++ b/internal/api/app_test.go
@@ -487,6 +487,64 @@ func TestInventoryCheckUsesEmbyProviderAndSeasons(t *testing.T) {
 	}
 }
 
+func TestBangumiSearchUsesV0EndpointAndReturnsResults(t *testing.T) {
+	app := newTestApp(t)
+	bgm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v0/search/subjects" {
+			t.Fatalf("unexpected Bangumi request %s %s", r.Method, r.URL.String())
+		}
+		if got := r.URL.Query().Get("limit"); got != "20" {
+			t.Fatalf("limit query = %q", got)
+		}
+		if got := r.URL.Query().Get("offset"); got != "0" {
+			t.Fatalf("offset query = %q", got)
+		}
+		if ct := r.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+			t.Fatalf("content-type = %q", ct)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["keyword"] != "葬送的芙莉莲" || body["sort"] != "match" {
+			t.Fatalf("unexpected Bangumi body %#v", body)
+		}
+		filter, _ := body["filter"].(map[string]any)
+		if filter == nil || filter["nsfw"] != true {
+			t.Fatalf("missing Bangumi filter %#v", body["filter"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":400602,"type":2,"name":"Sousou no Frieren","name_cn":"葬送的芙莉莲","date":"2023-09-29","images":{"common":"https://example.test/frieren.jpg"},"rating":{"score":8.8,"rank":10},"eps":28,"tags":[{"name":"漫画改"}]}]}`))
+	}))
+	defer bgm.Close()
+	app.cfg.BangumiAPIURL = bgm.URL
+
+	_ = doJSON(app, http.MethodPost, "/api/v1/users/register", `{"username":"admin","password":"admin123456"}`, nil)
+	login := doJSON(app, http.MethodPost, "/api/v1/auth/login", `{"username":"admin","password":"admin123456"}`, nil)
+	cookie := findCookie(login.Result().Cookies(), "twilight_session")
+	resp := doJSON(app, http.MethodGet, "/api/v1/media/search?q=%E8%91%AC%E9%80%81%E7%9A%84%E8%8A%99%E8%8E%89%E8%8E%B2&source=bangumi", ``, []*http.Cookie{cookie})
+	if resp.Code != http.StatusOK || !strings.Contains(resp.Body.String(), `"source":"bangumi"`) || !strings.Contains(resp.Body.String(), "葬送的芙莉莲") {
+		t.Fatalf("bangumi search status=%d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestBangumiSearchErrorIsVisibleForBangumiSource(t *testing.T) {
+	app := newTestApp(t)
+	bgm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"description":"bad bangumi request"}`, http.StatusBadGateway)
+	}))
+	defer bgm.Close()
+	app.cfg.BangumiAPIURL = bgm.URL
+
+	_ = doJSON(app, http.MethodPost, "/api/v1/users/register", `{"username":"admin","password":"admin123456"}`, nil)
+	login := doJSON(app, http.MethodPost, "/api/v1/auth/login", `{"username":"admin","password":"admin123456"}`, nil)
+	cookie := findCookie(login.Result().Cookies(), "twilight_session")
+	resp := doJSON(app, http.MethodGet, "/api/v1/media/search?q=test&source=bangumi", ``, []*http.Cookie{cookie})
+	if resp.Code != http.StatusBadGateway || !strings.Contains(resp.Body.String(), "Bangumi 搜索失败") {
+		t.Fatalf("bangumi failure status=%d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
 func TestSystemUpdateRejectsUnsafeRepoURL(t *testing.T) {
 	app := newTestApp(t)
 	_ = doJSON(app, http.MethodPost, "/api/v1/users/register", `{"username":"admin","password":"admin123456"}`, nil)
@@ -686,6 +744,23 @@ func TestTelegramBindConfirmRequiresInternalSecret(t *testing.T) {
 	allowed := doJSONWithHeaders(app, http.MethodPost, "/api/v1/users/me/telegram/bind-confirm", `{"code":"ABCDEFGH","telegram_id":42}`, nil, map[string]string{"X-Internal-Secret": "test-secret"})
 	if allowed.Code != http.StatusOK {
 		t.Fatalf("bind confirm with secret = %d body=%s", allowed.Code, allowed.Body.String())
+	}
+}
+
+func TestTelegramEndpointAcceptsCommonBaseURLs(t *testing.T) {
+	app := newTestApp(t)
+	app.cfg.TelegramMode = true
+	app.cfg.TelegramBotToken = "123:ABC"
+	cases := map[string]string{
+		"https://api.telegram.org":            "https://api.telegram.org/bot123:ABC/getMe",
+		"https://api.telegram.org/bot":        "https://api.telegram.org/bot123:ABC/getMe",
+		"https://api.telegram.org/bot123:ABC": "https://api.telegram.org/bot123:ABC/getMe",
+	}
+	for base, want := range cases {
+		app.cfg.TelegramAPIURL = base
+		if got := app.telegramEndpoint("getMe"); got != want {
+			t.Fatalf("telegramEndpoint(%q) = %q, want %q", base, got, want)
+		}
 	}
 }
 

--- a/internal/api/bangumi_client.go
+++ b/internal/api/bangumi_client.go
@@ -3,12 +3,23 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
 func (a *App) searchBangumi(ctx context.Context, query string, limit int) ([]map[string]any, error) {
-	endpoint := strings.TrimRight(a.cfg.BangumiAPIURL, "/") + "/search/subjects"
-	body := map[string]any{"keyword": query, "filter": map[string]any{"type": []int{2, 6}}, "sort": "match", "limit": limit}
+	endpoint, err := bangumiEndpoint(a.cfg.BangumiAPIURL, "/search/subjects", url.Values{
+		"limit":  {fmt.Sprint(limit)},
+		"offset": {"0"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	body := map[string]any{
+		"keyword": query,
+		"sort":    "match",
+		"filter":  map[string]any{"type": []int{2, 6}, "nsfw": true},
+	}
 	var payload map[string]any
 	if err := postJSON(ctx, endpoint, a.bangumiHeaders(), body, &payload); err != nil {
 		return nil, err
@@ -25,7 +36,10 @@ func (a *App) searchBangumi(ctx context.Context, query string, limit int) ([]map
 }
 
 func (a *App) getBangumi(ctx context.Context, id string) (map[string]any, error) {
-	endpoint := strings.TrimRight(a.cfg.BangumiAPIURL, "/") + "/subjects/" + id
+	endpoint, err := bangumiEndpoint(a.cfg.BangumiAPIURL, "/subjects/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
 	var payload map[string]any
 	if err := getJSON(ctx, endpoint, a.bangumiHeaders(), &payload); err != nil {
 		return nil, err
@@ -39,6 +53,26 @@ func (a *App) bangumiHeaders() map[string]string {
 		headers["Authorization"] = "Bearer " + a.cfg.BangumiToken
 	}
 	return headers
+}
+
+func bangumiEndpoint(base, path string, values url.Values) (string, error) {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "https://api.bgm.tv/v0"
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	if !strings.HasSuffix(parsed.Path, "/v0") {
+		parsed.Path += "/v0"
+	}
+	parsed.Path += "/" + strings.TrimLeft(path, "/")
+	if values != nil {
+		parsed.RawQuery = values.Encode()
+	}
+	return parsed.String(), nil
 }
 
 func bangumiToMedia(item map[string]any) map[string]any {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1421,8 +1421,9 @@ func (a *App) handleSystemInfo(w http.ResponseWriter, r *http.Request, _ Params)
 }
 
 func (a *App) publicTelegramBotInfo(ctx context.Context) map[string]any {
-	empty := map[string]any{"username": nil, "url": nil}
+	empty := map[string]any{"username": nil, "url": nil, "enabled": a.cfg.TelegramMode, "configured": strings.TrimSpace(a.cfg.TelegramBotToken) != "", "ok": false, "error": ""}
 	if !a.telegramAvailable() {
+		empty["error"] = "Telegram 未启用或未配置 Bot Token"
 		return empty
 	}
 	token := strings.TrimSpace(a.cfg.TelegramBotToken)
@@ -1442,13 +1443,19 @@ func (a *App) publicTelegramBotInfo(ctx context.Context) map[string]any {
 	if err == nil {
 		username := strings.TrimPrefix(asString(me["username"]), "@")
 		if telegramPublicUsernamePattern.MatchString(username) {
-			bot = map[string]any{"username": username, "url": "https://t.me/" + username}
+			bot = map[string]any{"username": username, "url": "https://t.me/" + username, "enabled": a.cfg.TelegramMode, "configured": true, "ok": true, "error": ""}
 		}
+	} else {
+		bot["error"] = err.Error()
 	}
 
 	a.telegramBotMu.Lock()
 	a.telegramBotCacheToken = token
-	a.telegramBotCacheUntil = now.Add(10 * time.Minute)
+	if err == nil {
+		a.telegramBotCacheUntil = now.Add(10 * time.Minute)
+	} else {
+		a.telegramBotCacheUntil = now.Add(30 * time.Second)
+	}
 	a.telegramBotCache = cloneMap(bot)
 	a.telegramBotMu.Unlock()
 	return bot
@@ -1524,7 +1531,7 @@ func (a *App) handleServerIcon(w http.ResponseWriter, r *http.Request, _ Params)
 		}
 	}
 	w.Header().Set("Content-Type", "image/png")
-	w.Header().Set("Cache-Control", "public, max-age=86400")
+	w.Header().Set("Cache-Control", "public, max-age=300")
 	_, _ = w.Write(serverIconPNG)
 }
 
@@ -1538,6 +1545,11 @@ func (a *App) publicServerIconURL() string {
 			return value
 		}
 		return "/api/v1/system/server-icon"
+	}
+	if iconPath, _, okIcon := a.configuredServerIconPath(); okIcon {
+		if info, err := os.Stat(iconPath); err == nil {
+			return "/api/v1/system/server-icon?v=" + strconv.FormatInt(info.ModTime().UnixNano(), 36) + "-" + strconv.FormatInt(info.Size(), 36)
+		}
 	}
 	return "/api/v1/system/server-icon"
 }
@@ -1731,18 +1743,59 @@ func (a *App) handleAPIRoutes(w http.ResponseWriter, r *http.Request, _ Params) 
 }
 
 func (a *App) handleBotTest(w http.ResponseWriter, r *http.Request, _ Params) {
-	if a.cfg.TelegramBotToken == "" {
-		fail(w, http.StatusBadRequest, "未配置 Telegram Bot Token")
+	results := []map[string]any{}
+	if !a.cfg.TelegramMode {
+		results = append(results, map[string]any{"target": "配置", "success": false, "error": "telegram_mode 未启用"})
+		ok(w, "测试完成", map[string]any{"results": results, "runtime": a.telegramRuntimeStatus()})
 		return
 	}
-	apiURL := strings.TrimRight(firstNonEmpty(a.cfg.TelegramAPIURL, "https://api.telegram.org"), "/") + "/bot" + a.cfg.TelegramBotToken + "/getMe"
-	var payload map[string]any
-	if err := getJSON(r.Context(), apiURL, nil, &payload); err != nil {
-		ok(w, "测试完成", map[string]any{"results": []map[string]any{{"target": "bot", "success": false, "error": err.Error()}}})
+	if strings.TrimSpace(a.cfg.TelegramBotToken) == "" {
+		results = append(results, map[string]any{"target": "Bot Token", "success": false, "error": "未配置 Telegram Bot Token"})
+		ok(w, "测试完成", map[string]any{"results": results, "runtime": a.telegramRuntimeStatus()})
 		return
 	}
-	result, _ := payload["result"].(map[string]any)
-	ok(w, "测试完成", map[string]any{"results": []map[string]any{{"target": "bot", "success": payload["ok"] == true, "username": result["username"]}}})
+	testCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	me, err := a.telegramGetMe(testCtx)
+	if err != nil {
+		results = append(results, map[string]any{"target": "Bot getMe", "success": false, "error": err.Error()})
+		ok(w, "测试完成", map[string]any{"results": results, "runtime": a.telegramRuntimeStatus()})
+		return
+	}
+	botID := int64(numeric(me["id"]))
+	username := strings.TrimPrefix(asString(me["username"]), "@")
+	results = append(results, map[string]any{"target": "Bot getMe", "success": true, "username": username, "bot_id": zeroNil(botID)})
+	for _, chatID := range telegramChatIDs(a.cfg.TelegramGroupIDs) {
+		var chat map[string]any
+		err := a.telegramPost(testCtx, "getChat", map[string]any{"chat_id": chatID}, &chat)
+		item := map[string]any{"target": "群组 " + chatID, "success": err == nil}
+		if err != nil {
+			item["error"] = err.Error()
+		} else {
+			item["title"] = firstNonEmpty(asString(chat["title"]), asString(chat["username"]))
+			if botID != 0 {
+				if member, memberErr := a.telegramGetChatMember(testCtx, chatID, botID); memberErr != nil {
+					item["success"] = false
+					item["error"] = memberErr.Error()
+				} else {
+					item["bot_status"] = asString(member["status"])
+				}
+			}
+		}
+		results = append(results, item)
+	}
+	for _, chatID := range telegramChatIDs(a.cfg.TelegramChannelIDs) {
+		var chat map[string]any
+		err := a.telegramPost(testCtx, "getChat", map[string]any{"chat_id": chatID}, &chat)
+		item := map[string]any{"target": "频道 " + chatID, "success": err == nil}
+		if err != nil {
+			item["error"] = err.Error()
+		} else {
+			item["title"] = firstNonEmpty(asString(chat["title"]), asString(chat["username"]))
+		}
+		results = append(results, item)
+	}
+	ok(w, "测试完成", map[string]any{"results": results, "runtime": a.telegramRuntimeStatus()})
 }
 
 func (a *App) handleEmbyStatus(w http.ResponseWriter, r *http.Request, _ Params) {

--- a/internal/api/http_json_client.go
+++ b/internal/api/http_json_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -41,12 +42,16 @@ func doJSONRequest(req *http.Request, dst any) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("remote status %d", resp.StatusCode)
-	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
 	if err != nil {
 		return err
+	}
+	if resp.StatusCode >= 400 {
+		detail := strings.TrimSpace(string(data))
+		if detail != "" {
+			return fmt.Errorf("remote status %d: %s", resp.StatusCode, truncateString(detail, 300))
+		}
+		return fmt.Errorf("remote status %d", resp.StatusCode)
 	}
 	if dst == nil {
 		return nil

--- a/internal/api/media_request_handlers.go
+++ b/internal/api/media_request_handlers.go
@@ -15,8 +15,18 @@ func (a *App) handleMediaSearch(w http.ResponseWriter, r *http.Request, _ Params
 	limit := clamp(queryInt(r, "limit", queryInt(r, "per_page", 20)), 1, 50)
 	source := normalizeSource(firstNonEmpty(r.URL.Query().Get("source"), "all"))
 	mediaType := firstNonEmpty(r.URL.Query().Get("type"), r.URL.Query().Get("media_type"))
-	results, message := a.searchMedia(r.Context(), query, source, mediaType, limit, false)
-	ok(w, message, map[string]any{"results": results, "total": len(results)})
+	results, message, sourceErrors := a.searchMedia(r.Context(), query, source, mediaType, limit, false)
+	if source != "all" {
+		if detail := sourceErrors[source]; detail != "" {
+			fail(w, http.StatusBadGateway, detail)
+			return
+		}
+	}
+	data := map[string]any{"results": results, "total": len(results)}
+	if len(sourceErrors) > 0 {
+		data["warnings"] = sourceErrors
+	}
+	ok(w, message, data)
 }
 
 func (a *App) handleMediaDetail(w http.ResponseWriter, r *http.Request, params Params) {

--- a/internal/api/media_service.go
+++ b/internal/api/media_service.go
@@ -2,35 +2,44 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 )
 
-func (a *App) searchMedia(ctx context.Context, query, source, mediaType string, limit int, includeDetails bool) ([]map[string]any, string) {
+func (a *App) searchMedia(ctx context.Context, query, source, mediaType string, limit int, includeDetails bool) ([]map[string]any, string, map[string]string) {
 	if strings.TrimSpace(query) == "" {
-		return []map[string]any{}, "OK"
+		return []map[string]any{}, "OK", nil
 	}
 	if kind, id, mt, ok := detectMediaID(query); ok {
 		if result, found := a.mediaDetail(ctx, kind, id, mt); found {
-			return []map[string]any{result}, "OK"
+			return []map[string]any{result}, "OK", nil
 		}
 	}
 	results := []map[string]any{}
+	sourceErrors := map[string]string{}
 	if source == "all" || source == "tmdb" {
 		if tmdb, err := a.searchTMDB(ctx, query, mediaType, limit); err == nil {
 			results = append(results, tmdb...)
+		} else {
+			sourceErrors["tmdb"] = fmt.Sprintf("TMDB 搜索失败：%v", err)
 		}
 	}
 	if source == "all" || source == "bangumi" {
 		if bgm, err := a.searchBangumi(ctx, query, limit); err == nil {
 			results = append(results, bgm...)
+		} else {
+			sourceErrors["bangumi"] = fmt.Sprintf("Bangumi 搜索失败：%v", err)
 		}
 	}
 	if len(results) > limit {
 		results = results[:limit]
 	}
-	return results, "OK"
+	if len(sourceErrors) == 0 {
+		sourceErrors = nil
+	}
+	return results, "OK", sourceErrors
 }
 
 func (a *App) mediaDetail(ctx context.Context, source, id, mediaType string) (map[string]any, bool) {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -208,6 +208,7 @@ func (a *App) registerAdminRoutes() {
 	a.add(http.MethodPost, "/api/v1/admin/telegram/kick-unbound", AuthAdmin, a.handleTelegramKickUnbound)
 	a.add(http.MethodGet, "/api/v1/admin/scheduler/jobs", AuthAdmin, a.handleSchedulerJobs)
 	a.add(http.MethodPost, "/api/v1/admin/scheduler/jobs/:job_id/run", AuthAdmin, a.handleSchedulerRunV2)
+	a.add(http.MethodPost, "/api/v1/admin/scheduler/jobs/:job_id/terminate", AuthAdmin, a.handleSchedulerTerminate)
 	a.add(http.MethodGet, "/api/v1/admin/scheduler/jobs/:job_id/last-run", AuthAdmin, a.handleSchedulerLastRun)
 	a.add(http.MethodGet, "/api/v1/admin/scheduler/jobs/:job_id/history", AuthAdmin, a.handleSchedulerHistory)
 	a.add(http.MethodPut, "/api/v1/admin/scheduler/jobs/:job_id/schedule", AuthAdmin, a.handleSchedulerSchedule)

--- a/internal/api/scheduler_daemon.go
+++ b/internal/api/scheduler_daemon.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -82,15 +83,26 @@ func (a *App) schedulerJobDue(jobID string, spec map[string]any, now time.Time) 
 }
 
 func (a *App) runScheduledJob(ctx context.Context, jobID string) {
-	if !a.markSchedulerRunning(jobID) {
+	runCtx, finish, ok := a.startSchedulerRun(ctx, jobID)
+	if !ok {
 		return
 	}
-	defer a.clearSchedulerRunning(jobID)
+	defer finish()
 	started := time.Now().Unix()
 	run := store.SchedulerRun{JobID: jobID, Type: "auto", Trigger: "scheduler", Status: "running", Message: "running", StartedAt: started}
 	_ = a.store.AddSchedulerRun(run)
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/scheduler/internal", nil)
+	req, _ := http.NewRequestWithContext(runCtx, http.MethodPost, "/scheduler/internal", nil)
 	summary, logs, err := a.runSchedulerJob(req, jobID)
+	run = schedulerFinishedRun(jobID, "auto", "scheduler", started, summary, logs, err)
+	_ = a.store.AddSchedulerRun(run)
+	if err != nil {
+		slog.Warn("scheduler job failed", "job_id", jobID, "error", err)
+	} else {
+		slog.Info("scheduler job completed", "job_id", jobID)
+	}
+}
+
+func schedulerFinishedRun(jobID, runType, trigger string, started int64, summary map[string]any, logs []string, err error) store.SchedulerRun {
 	status := "success"
 	message := "job completed"
 	errText := ""
@@ -98,12 +110,16 @@ func (a *App) runScheduledJob(ctx context.Context, jobID string) {
 		status = "failed"
 		message = err.Error()
 		errText = err.Error()
+		if errors.Is(err, context.Canceled) {
+			message = "job terminated by administrator"
+			errText = message
+		}
 	}
 	finished := time.Now().Unix()
-	_ = a.store.AddSchedulerRun(store.SchedulerRun{
+	return store.SchedulerRun{
 		JobID:      jobID,
-		Type:       "auto",
-		Trigger:    "scheduler",
+		Type:       runType,
+		Trigger:    trigger,
 		Status:     status,
 		Message:    message,
 		StartedAt:  started,
@@ -112,11 +128,6 @@ func (a *App) runScheduledJob(ctx context.Context, jobID string) {
 		Summary:    summary,
 		Logs:       logs,
 		Error:      errText,
-	})
-	if err != nil {
-		slog.Warn("scheduler job failed", "job_id", jobID, "error", err)
-	} else {
-		slog.Info("scheduler job completed", "job_id", jobID)
 	}
 }
 
@@ -181,13 +192,45 @@ func parseClock(value string, fallbackHour, fallbackMinute int) (int, int) {
 	return clamp(hour, 0, 23), clamp(minute, 0, 59)
 }
 
-var schedulerProcessLocks sync.Map
-
-func (a *App) markSchedulerRunning(jobID string) bool {
-	_, loaded := schedulerProcessLocks.LoadOrStore(jobID, true)
-	return !loaded
+type schedulerProcessRun struct {
+	cancel  context.CancelFunc
+	started int64
 }
 
-func (a *App) clearSchedulerRunning(jobID string) {
-	schedulerProcessLocks.Delete(jobID)
+var schedulerProcessLocks sync.Map
+
+func (a *App) startSchedulerRun(ctx context.Context, jobID string) (context.Context, func(), bool) {
+	runCtx, cancel := context.WithCancel(ctx)
+	run := &schedulerProcessRun{cancel: cancel, started: time.Now().Unix()}
+	actual, loaded := schedulerProcessLocks.LoadOrStore(jobID, run)
+	if loaded {
+		cancel()
+		_ = actual
+		return ctx, func() {}, false
+	}
+	finish := func() {
+		cancel()
+		if current, ok := schedulerProcessLocks.Load(jobID); ok && current == run {
+			schedulerProcessLocks.Delete(jobID)
+		}
+	}
+	return runCtx, finish, true
+}
+
+func (a *App) schedulerJobRunning(jobID string) bool {
+	_, ok := schedulerProcessLocks.Load(jobID)
+	return ok
+}
+
+func (a *App) terminateSchedulerJob(jobID string) bool {
+	value, ok := schedulerProcessLocks.Load(jobID)
+	if !ok {
+		return false
+	}
+	run, ok := value.(*schedulerProcessRun)
+	if !ok || run.cancel == nil {
+		return false
+	}
+	run.cancel()
+	return true
 }

--- a/internal/api/scheduler_handlers.go
+++ b/internal/api/scheduler_handlers.go
@@ -6,18 +6,18 @@ import (
 )
 
 var schedulerJobs = []map[string]any{
-	{"id": "check_expired", "name": "Check expired users", "description": "Disable expired Emby access", "manual_only": false, "enabled": true},
-	{"id": "check_expiring", "name": "Check expiring users", "description": "Scan users that will expire soon", "manual_only": false, "enabled": true},
-	{"id": "expiry_reminders", "name": "Expiry reminders", "description": "Send expiry reminders", "manual_only": false, "enabled": true},
-	{"id": "daily_stats", "name": "Daily stats", "description": "Generate daily statistics summary", "manual_only": false, "enabled": true},
-	{"id": "cleanup_sessions", "name": "Session cleanup", "description": "Check active Emby sessions", "manual_only": false, "enabled": true},
-	{"id": "emby_sync", "name": "Emby sync", "description": "Sync local and Emby user state", "manual_only": true, "enabled": true},
-	{"id": "cleanup_no_emby", "name": "Clean users without Emby", "description": "Clean long-unbound Emby users", "manual_only": false, "enabled": true, "runtime_params": []string{"days", "preserve_tg_bound", "ignore_enabled_flag"}},
-	{"id": "enforce_group_membership", "name": "Telegram group enforcement", "description": "Validate required Telegram group membership", "manual_only": false, "enabled": true},
-	{"id": "check_telegram_bindings", "name": "Telegram binding check", "description": "Detect duplicate or abnormal bindings", "manual_only": false, "enabled": true},
-	{"id": "system_auto_update", "name": "System auto update", "description": "Run system update checks", "manual_only": false, "enabled": false},
-	{"id": "cleanup_unused_uploads", "name": "Clean unused uploads", "description": "Delete unreferenced avatars and backgrounds", "manual_only": false, "enabled": true},
-	{"id": "kick_unknown_group_members", "name": "Kick unknown group members", "description": "Kick unrecognized members from observed roster", "manual_only": true, "enabled": true, "runtime_params": []string{"dry_run", "max_per_run"}},
+	{"id": "check_expired", "name": "检查已过期用户", "description": "扫描已过期账号，并按规则禁用系统或 Emby 访问。", "manual_only": false, "enabled": true},
+	{"id": "check_expiring", "name": "检查即将到期用户", "description": "统计近期即将到期的用户，供管理员确认续期风险。", "manual_only": false, "enabled": true},
+	{"id": "expiry_reminders", "name": "发送到期提醒", "description": "向即将到期且已绑定 Telegram 的用户发送续期提醒。", "manual_only": false, "enabled": true},
+	{"id": "daily_stats", "name": "每日统计", "description": "生成每日用户与活跃状态汇总。", "manual_only": false, "enabled": true},
+	{"id": "cleanup_sessions", "name": "会话巡检", "description": "读取 Emby 当前会话，统计活跃播放情况。", "manual_only": false, "enabled": true},
+	{"id": "emby_sync", "name": "同步 Emby 用户", "description": "同步本地用户与 Emby 用户名称、启用状态等信息。", "manual_only": true, "enabled": true},
+	{"id": "cleanup_no_emby", "name": "清理未补建 Emby 用户", "description": "清理长期未补建 Emby 的本地账号，可配置保留已绑定 Telegram 的用户。", "manual_only": false, "enabled": true, "runtime_params": []string{"days", "preserve_tg_bound", "ignore_enabled_flag"}},
+	{"id": "enforce_group_membership", "name": "Telegram 群成员校验", "description": "校验用户是否仍在要求加入的 Telegram 群组内，并按配置处理退群用户。", "manual_only": false, "enabled": true},
+	{"id": "check_telegram_bindings", "name": "Telegram 绑定检查", "description": "检查重复或异常的 Telegram 绑定关系。", "manual_only": false, "enabled": true},
+	{"id": "system_auto_update", "name": "系统自动更新", "description": "按配置拉取可信 Git 仓库更新，并可选择重启服务。", "manual_only": false, "enabled": false},
+	{"id": "cleanup_unused_uploads", "name": "清理未使用上传文件", "description": "删除未被头像、背景或服务器图标引用的历史上传文件。", "manual_only": false, "enabled": true},
+	{"id": "kick_unknown_group_members", "name": "踢出未知 Telegram 群成员", "description": "根据已观察到的群成员名册，踢出无系统账号、未绑定 Emby 或已禁用的成员。", "manual_only": true, "enabled": true, "runtime_params": []string{"dry_run", "max_per_run"}},
 }
 
 func (a *App) handleSchedulerJobs(w http.ResponseWriter, r *http.Request, _ Params) {
@@ -37,10 +37,23 @@ func (a *App) handleSchedulerJobs(w http.ResponseWriter, r *http.Request, _ Para
 		if runs := a.store.SchedulerRuns(jobID, 1); len(runs) > 0 {
 			item["last_run"] = runs[0]
 		}
-		item["is_running"] = false
+		item["is_running"] = a.schedulerJobRunning(jobID)
 		jobs = append(jobs, item)
 	}
 	ok(w, "OK", map[string]any{"jobs": jobs})
+}
+
+func (a *App) handleSchedulerTerminate(w http.ResponseWriter, r *http.Request, params Params) {
+	jobID := params["job_id"]
+	if !schedulerJobExists(jobID) {
+		fail(w, http.StatusNotFound, "job not found")
+		return
+	}
+	if !a.terminateSchedulerJob(jobID) {
+		fail(w, http.StatusConflict, "job is not running")
+		return
+	}
+	ok(w, "job termination requested", map[string]any{"job_id": jobID, "terminated": true})
 }
 func (a *App) handleSchedulerLastRun(w http.ResponseWriter, r *http.Request, params Params) {
 	runs := a.store.SchedulerRuns(params["job_id"], 1)

--- a/internal/api/scheduler_runner.go
+++ b/internal/api/scheduler_runner.go
@@ -48,17 +48,17 @@ func (a *App) sendExpiryReminders(ctx context.Context, days int) map[string]any 
 
 func (a *App) handleSchedulerRunV2(w http.ResponseWriter, r *http.Request, params Params) {
 	now := time.Now().Unix()
-	summary, logs, err := a.runSchedulerJob(r, params["job_id"])
-	status := "success"
-	message := "job completed"
-	errText := ""
-	if err != nil {
-		status = "failed"
-		message = err.Error()
-		errText = err.Error()
+	jobID := params["job_id"]
+	runCtx, finish, okRun := a.startSchedulerRun(r.Context(), jobID)
+	if !okRun {
+		fail(w, http.StatusConflict, "job is already running")
+		return
 	}
-	finished := time.Now().Unix()
-	run := store.SchedulerRun{JobID: params["job_id"], Type: "manual", Trigger: "manual", Status: status, Message: message, StartedAt: now, FinishedAt: finished, EndedAt: finished, Summary: summary, Logs: logs, Error: errText}
+	defer finish()
+	_ = a.store.AddSchedulerRun(store.SchedulerRun{JobID: jobID, Type: "manual", Trigger: "manual", Status: "running", Message: "running", StartedAt: now})
+	req := r.WithContext(runCtx)
+	summary, logs, err := a.runSchedulerJob(req, jobID)
+	run := schedulerFinishedRun(jobID, "manual", "manual", now, summary, logs, err)
 	_ = a.store.AddSchedulerRun(run)
 	ok(w, "job executed", map[string]any{"job_id": run.JobID, "last_run": run})
 }
@@ -68,12 +68,18 @@ func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []
 		return map[string]any{"success": false}, nil, fmt.Errorf("job not found")
 	}
 	params := schedulerRequestParams(r)
+	if err := r.Context().Err(); err != nil {
+		return map[string]any{"success": false, "terminated": true}, []string{"job terminated before execution"}, err
+	}
 	now := time.Now().Unix()
 	switch jobID {
 	case "check_expired":
 		disabled := 0
 		embyDisabled := 0
 		for _, u := range a.store.ListUsers() {
+			if err := r.Context().Err(); err != nil {
+				return map[string]any{"success": false, "terminated": true, "disabled": disabled, "emby_disabled": embyDisabled}, []string{"job terminated"}, err
+			}
 			if u.Active && u.ExpiredAt > 0 && u.ExpiredAt < now {
 				// For invited users (have invite relation), only disable Emby access
 				// but keep the account active so they can still log in and renew
@@ -111,6 +117,9 @@ func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []
 		deadline := time.Now().Add(time.Duration(days) * 24 * time.Hour).Unix()
 		count := 0
 		for _, u := range a.store.ListUsers() {
+			if err := r.Context().Err(); err != nil {
+				return map[string]any{"success": false, "terminated": true, "expiring": count, "days": days}, []string{"job terminated"}, err
+			}
 			if u.Active && u.ExpiredAt > now && u.ExpiredAt <= deadline {
 				count++
 			}
@@ -150,6 +159,9 @@ func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []
 		}
 		updatedNames, syncedState, missing := 0, 0, 0
 		for _, u := range a.store.ListUsers() {
+			if err := r.Context().Err(); err != nil {
+				return map[string]any{"success": false, "terminated": true, "updated_names": updatedNames, "synced_state": syncedState, "missing": missing}, []string{"job terminated"}, err
+			}
 			if u.EmbyID == "" {
 				continue
 			}
@@ -188,6 +200,9 @@ func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []
 		deleted := 0
 		failed := 0
 		for _, u := range a.store.ListUsers() {
+			if err := r.Context().Err(); err != nil {
+				return map[string]any{"success": false, "terminated": true, "candidates": candidates, "deleted": deleted, "failed": failed, "dry_run": dryRun}, []string{"job terminated"}, err
+			}
 			if u.Role == store.RoleAdmin || u.Role == store.RoleWhitelist || u.EmbyID != "" {
 				continue
 			}
@@ -216,6 +231,9 @@ func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []
 		seen := map[int64]int64{}
 		duplicates := 0
 		for _, u := range a.store.ListUsers() {
+			if err := r.Context().Err(); err != nil {
+				return map[string]any{"success": false, "terminated": true, "duplicates": duplicates, "bound": len(seen)}, []string{"job terminated"}, err
+			}
 			if u.TelegramID == 0 {
 				continue
 			}
@@ -276,6 +294,11 @@ func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []
 		kicked, skipped, failedCount, notInGroup, scanned := 0, 0, 0, 0, 0
 		logs := []string{}
 		for _, target := range targets {
+			if err := r.Context().Err(); err != nil {
+				summary["success"] = false
+				summary["terminated"] = true
+				return summary, append(logs, "job terminated"), err
+			}
 			if scanned >= maxPerRun {
 				break
 			}

--- a/internal/api/telegram.go
+++ b/internal/api/telegram.go
@@ -25,10 +25,37 @@ func (a *App) telegramAvailable() bool {
 func (a *App) telegramEndpoint(method string) string {
 	base := strings.TrimRight(firstNonEmpty(a.cfg.TelegramAPIURL, "https://api.telegram.org"), "/")
 	token := strings.TrimSpace(a.cfg.TelegramBotToken)
+	if strings.HasSuffix(base, "/bot"+token) {
+		return base + "/" + method
+	}
 	if strings.HasSuffix(base, "/bot") {
 		return base + token + "/" + method
 	}
 	return base + "/bot" + token + "/" + method
+}
+
+func (a *App) setTelegramRuntimeStatus(polling bool, err error) {
+	a.telegramStatusMu.Lock()
+	defer a.telegramStatusMu.Unlock()
+	a.telegramPolling = polling
+	if err != nil {
+		a.telegramLastError = err.Error()
+		a.telegramLastErrorAt = time.Now().Unix()
+		return
+	}
+	a.telegramLastError = ""
+	a.telegramLastOKAt = time.Now().Unix()
+}
+
+func (a *App) telegramRuntimeStatus() map[string]any {
+	a.telegramStatusMu.Lock()
+	defer a.telegramStatusMu.Unlock()
+	return map[string]any{
+		"polling":       a.telegramPolling,
+		"last_ok_at":    zeroNil(a.telegramLastOKAt),
+		"last_error_at": zeroNil(a.telegramLastErrorAt),
+		"last_error":    a.telegramLastError,
+	}
 }
 
 func (a *App) telegramPost(ctx context.Context, method string, body map[string]any, dst any) error {

--- a/internal/api/telegram_bot.go
+++ b/internal/api/telegram_bot.go
@@ -25,6 +25,7 @@ func (a *App) RunTelegramBot(ctx context.Context) error {
 		}
 		a.reloadConfigIfChanged()
 		if !a.telegramAvailable() {
+			a.setTelegramRuntimeStatus(false, fmt.Errorf("Telegram bot is disabled or token is not configured"))
 			slog.Info("Telegram bot configuration disabled; waiting before next config check")
 			select {
 			case <-ctx.Done():
@@ -37,6 +38,7 @@ func (a *App) RunTelegramBot(ctx context.Context) error {
 		if currentConfig != activeConfig {
 			me, err := a.telegramGetMe(ctx)
 			if err != nil {
+				a.setTelegramRuntimeStatus(false, err)
 				slog.Warn("Telegram bot initialization failed", "error", err)
 				select {
 				case <-ctx.Done():
@@ -47,10 +49,12 @@ func (a *App) RunTelegramBot(ctx context.Context) error {
 			}
 			activeConfig = currentConfig
 			offset = 0
+			a.setTelegramRuntimeStatus(true, nil)
 			slog.Info("Telegram bot polling started", "username", me["username"])
 		}
 		updates, err := a.telegramGetUpdates(ctx, offset)
 		if err != nil {
+			a.setTelegramRuntimeStatus(true, err)
 			slog.Warn("Telegram getUpdates failed", "error", err)
 			select {
 			case <-ctx.Done():
@@ -60,6 +64,7 @@ func (a *App) RunTelegramBot(ctx context.Context) error {
 			}
 		}
 		for _, update := range updates {
+			a.setTelegramRuntimeStatus(true, nil)
 			if id := numeric(update["update_id"]); id >= offset {
 				offset = id + 1
 			}

--- a/webui/src/app/(main)/admin/config/page.tsx
+++ b/webui/src/app/(main)/admin/config/page.tsx
@@ -55,6 +55,7 @@ import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useAsyncResource } from "@/hooks/use-async-resource";
 import { PageError } from "@/components/layout/page-state";
 import { api } from "@/lib/api";
+import { useSystemStore } from "@/store/system";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Alert,
@@ -770,6 +771,7 @@ function SectionNav({
 export default function AdminConfigPage() {
   const { toast } = useToast();
   const { confirm } = useConfirm();
+  const { fetchInfo: fetchSystemInfo } = useSystemStore();
 
   // 源文件编辑状态
   const [configContent, setConfigContent] = useState("");
@@ -1112,6 +1114,7 @@ export default function AdminConfigPage() {
       if (configContent) {
         await loadConfig();
       }
+      await fetchSystemInfo(true);
       toast({
         title: "上传成功",
         description: "服务器图标已保存并热重载。",

--- a/webui/src/app/(main)/admin/emby/page.tsx
+++ b/webui/src/app/(main)/admin/emby/page.tsx
@@ -158,16 +158,19 @@ export default function AdminEmbyPage() {
 
   // Bot test state
   const [isBotTesting, setIsBotTesting] = useState(false);
-  const [botResults, setBotResults] = useState<Array<{ target: string; success: boolean; error: string | null }> | null>(null);
+  const [botResults, setBotResults] = useState<Array<{ target: string; success: boolean; error: string | null; username?: string; bot_id?: number; title?: string; bot_status?: string }> | null>(null);
+  const [botRuntime, setBotRuntime] = useState<{ polling?: boolean; last_ok_at?: number | null; last_error_at?: number | null; last_error?: string } | null>(null);
 
   // Bot connectivity test
   const handleTestBot = useCallback(async () => {
     setIsBotTesting(true);
     setBotResults(null);
+    setBotRuntime(null);
     try {
       const res = await api.testBotConnectivity();
       if (res.success && res.data) {
         setBotResults(res.data.results);
+        setBotRuntime(res.data.runtime || null);
         const allOk = res.data.results.every((r) => r.success);
         toast({
           title: allOk ? "Bot 连通性测试成功" : "部分目标发送失败",
@@ -497,6 +500,14 @@ export default function AdminEmbyPage() {
           </CardHeader>
           {botResults && (
             <CardContent className="space-y-3">
+              {botRuntime && (
+                <div className="rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+                  <div>轮询状态：{botRuntime.polling ? "运行中" : "未运行或等待配置"}</div>
+                  {botRuntime.last_ok_at ? <div>最近成功：{new Date(botRuntime.last_ok_at * 1000).toLocaleString()}</div> : null}
+                  {botRuntime.last_error_at ? <div>最近错误时间：{new Date(botRuntime.last_error_at * 1000).toLocaleString()}</div> : null}
+                  {botRuntime.last_error ? <div className="break-words text-red-500">最近错误：{botRuntime.last_error}</div> : null}
+                </div>
+              )}
               <div className="grid gap-2 sm:grid-cols-2">
                 {botResults.map((r, i) => (
                   <div
@@ -517,6 +528,11 @@ export default function AdminEmbyPage() {
                     </div>
                     {r.error && (
                       <p className="text-xs text-red-500 mt-1">{r.error}</p>
+                    )}
+                    {!r.error && (r.username || r.title || r.bot_status) && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {[r.username ? `@${r.username}` : "", r.title || "", r.bot_status ? `Bot 状态：${r.bot_status}` : ""].filter(Boolean).join(" · ")}
+                      </p>
                     )}
                     {r.success && (
                       <p className="text-xs text-muted-foreground">发送成功</p>

--- a/webui/src/app/(main)/admin/scheduler/page.tsx
+++ b/webui/src/app/(main)/admin/scheduler/page.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
   RotateCcw,
   Settings2,
+  Square,
   TimerReset,
   XCircle,
 } from "lucide-react";
@@ -472,6 +473,7 @@ export default function AdminSchedulerPage() {
   const { toast } = useToast();
   const [jobs, setJobs] = useState<SchedulerJobItem[]>([]);
   const [running, setRunning] = useState<Record<string, boolean>>({});
+  const [terminating, setTerminating] = useState<Record<string, boolean>>({});
   const [rejoinEnabling, setRejoinEnabling] = useState(false);
   const pollTimerRef = useRef<number | null>(null);
 
@@ -581,6 +583,26 @@ export default function AdminSchedulerPage() {
     }
     void runJob(job);
   };
+
+  const handleTerminate = useCallback(
+    async (job: SchedulerJobItem) => {
+      setTerminating((p) => ({ ...p, [job.id]: true }));
+      try {
+        const res = await api.terminateSchedulerJob(job.id);
+        if (res.success) {
+          toast({ title: "已请求终止", description: `${job.name} 正在停止，请稍后刷新状态。`, variant: "success" });
+          await refresh();
+        } else {
+          toast({ title: "终止失败", description: res.message, variant: "destructive" });
+        }
+      } catch (err: any) {
+        toast({ title: "终止失败", description: err.message || "网络异常", variant: "destructive" });
+      } finally {
+        setTerminating((p) => ({ ...p, [job.id]: false }));
+      }
+    },
+    [refresh, toast],
+  );
 
   const handleParamConfirm = async () => {
     if (!paramJob) return;
@@ -786,7 +808,7 @@ export default function AdminSchedulerPage() {
                     </div>
                   )}
 
-                  <div className={job.manual_only ? "grid grid-cols-[1fr_auto] gap-2" : "grid grid-cols-[1fr_auto_auto] gap-2"}>
+                  <div className={job.manual_only ? "grid grid-cols-[1fr_auto_auto] gap-2" : "grid grid-cols-[1fr_auto_auto_auto] gap-2"}>
                     <Button
                       onClick={() => void handleTrigger(job)}
                       disabled={isRunning}
@@ -798,6 +820,19 @@ export default function AdminSchedulerPage() {
                         <PlayCircle className="mr-2 h-4 w-4" />
                       )}
                       {isRunning ? "运行中…" : "立即运行"}
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="icon"
+                      onClick={() => void handleTerminate(job)}
+                      disabled={!isRunning || Boolean(terminating[job.id])}
+                      title="终止当前运行"
+                    >
+                      {terminating[job.id] ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Square className="h-4 w-4" />
+                      )}
                     </Button>
                     {!job.manual_only && (
                       <Button

--- a/webui/src/app/(main)/media/page.tsx
+++ b/webui/src/app/(main)/media/page.tsx
@@ -265,6 +265,13 @@ export default function MediaPage() {
           const finalResults = Array.from(uniqueResults.values());
           setResults(finalResults);
           rememberCache(searchCacheRef.current, searchCacheKey, finalResults, MAX_SEARCH_CACHE_ENTRIES);
+          if (res.data.warnings && Object.keys(res.data.warnings).length > 0) {
+            toast({
+              title: "部分来源搜索失败",
+              description: Object.values(res.data.warnings).join("\n"),
+              variant: "destructive",
+            });
+          }
           
           if (finalResults.length === 0) {
             toast({
@@ -477,6 +484,12 @@ export default function MediaPage() {
     hidden: { opacity: 0, y: 20 },
     show: { opacity: 1, y: 0 }
   };
+  const compactSegmentClass = "grid w-full grid-cols-2 overflow-hidden rounded-xl border border-border/60 bg-secondary/80 p-0.5 sm:w-auto";
+  const compactSegmentButtonClass = "min-w-0 rounded-[0.65rem] px-3 py-1.5 text-xs font-bold transition-colors sm:px-4";
+  const sourceSegmentClass = "isolate flex h-14 w-full overflow-hidden rounded-[1.25rem] border border-border/70 bg-card/60 backdrop-blur-md dark:bg-slate-950/40 sm:w-auto";
+  const sourceSegmentButtonClass = "min-w-0 flex-1 px-3 text-sm font-bold transition-colors sm:flex-none sm:px-6";
+  const activeSegmentClass = "bg-primary text-primary-foreground";
+  const inactiveSegmentClass = "text-muted-foreground hover:bg-accent/80";
 
   return (
     <div className="space-y-8 pb-10">
@@ -506,16 +519,16 @@ export default function MediaPage() {
                 {/* 搜索模式切换 */}
                 <div className="flex items-center gap-4 flex-wrap">
                   <span className="text-xs font-black uppercase tracking-widest text-muted-foreground">Search Mode</span>
-                  <div className="grid w-full grid-cols-2 rounded-xl bg-secondary p-1 sm:w-auto">
+                  <div className={compactSegmentClass}>
                     <button 
                       onClick={() => setSearchMode("name")}
-                      className={cn("rounded-lg px-3 py-1.5 text-xs font-bold transition-all sm:px-4", searchMode === "name" ? "bg-white text-primary shadow-sm dark:bg-slate-950/80 dark:text-primary-foreground" : "text-muted-foreground")}
+                      className={cn(compactSegmentButtonClass, searchMode === "name" ? "bg-background text-primary shadow-sm dark:text-primary-foreground" : inactiveSegmentClass)}
                     >
                       名称搜索
                     </button>
                     <button 
                       onClick={() => setSearchMode("id")}
-                      className={cn("rounded-lg px-3 py-1.5 text-xs font-bold transition-all sm:px-4", searchMode === "id" ? "bg-white text-primary shadow-sm dark:bg-slate-950/80 dark:text-primary-foreground" : "text-muted-foreground")}
+                      className={cn(compactSegmentButtonClass, searchMode === "id" ? "bg-background text-primary shadow-sm dark:text-primary-foreground" : inactiveSegmentClass)}
                     >
                       ID 搜索
                     </button>
@@ -545,40 +558,40 @@ export default function MediaPage() {
                     />
                   </div>
                   
-                  <div className="flex w-full gap-2 rounded-[1.25rem] border border-white/50 bg-white/40 p-1 backdrop-blur-md dark:border-slate-700/70 dark:bg-slate-950/30 sm:w-auto">
+                  <div className={sourceSegmentClass}>
                     {searchMode === "name" && (
                       <button 
                         onClick={() => setSource("all")}
-                        className={cn("min-w-0 flex-1 rounded-xl px-3 text-sm font-bold transition-all sm:flex-none sm:px-6", source === "all" ? "bg-primary text-primary-foreground shadow-lg" : "text-muted-foreground hover:bg-accent")}
+                        className={cn(sourceSegmentButtonClass, source === "all" ? activeSegmentClass : inactiveSegmentClass)}
                       >
                         全部
                       </button>
                     )}
                     <button 
                       onClick={() => setSource("tmdb")}
-                      className={cn("min-w-0 flex-1 rounded-xl px-3 text-sm font-bold transition-all sm:flex-none sm:px-6", source === "tmdb" ? "bg-primary text-primary-foreground shadow-lg" : "text-muted-foreground hover:bg-accent")}
+                      className={cn(sourceSegmentButtonClass, source === "tmdb" ? activeSegmentClass : inactiveSegmentClass)}
                     >
                       TMDB
                     </button>
                     <button 
                       onClick={() => setSource("bangumi")}
-                      className={cn("min-w-0 flex-1 rounded-xl px-3 text-sm font-bold transition-all sm:flex-none sm:px-6", source === "bangumi" ? "bg-primary text-primary-foreground shadow-lg" : "text-muted-foreground hover:bg-accent")}
+                      className={cn(sourceSegmentButtonClass, source === "bangumi" ? activeSegmentClass : inactiveSegmentClass)}
                     >
                       Bangumi
                     </button>
                   </div>
 
                   {searchMode === "id" && source === "tmdb" && (
-                    <div className="flex w-full gap-2 rounded-[1.25rem] border border-white/50 bg-white/40 p-1 backdrop-blur-md dark:border-slate-700/70 dark:bg-slate-950/30 sm:w-auto">
+                    <div className={sourceSegmentClass}>
                       <button 
                         onClick={() => setMediaType("movie")}
-                        className={cn("flex-1 rounded-xl px-3 text-sm font-bold transition-all sm:flex-none sm:px-6", mediaType === "movie" ? "bg-primary text-primary-foreground shadow-lg" : "text-muted-foreground hover:bg-accent")}
+                        className={cn(sourceSegmentButtonClass, mediaType === "movie" ? activeSegmentClass : inactiveSegmentClass)}
                       >
                         电影
                       </button>
                       <button 
                         onClick={() => setMediaType("tv")}
-                        className={cn("flex-1 rounded-xl px-3 text-sm font-bold transition-all sm:flex-none sm:px-6", mediaType === "tv" ? "bg-primary text-primary-foreground shadow-lg" : "text-muted-foreground hover:bg-accent")}
+                        className={cn(sourceSegmentButtonClass, mediaType === "tv" ? activeSegmentClass : inactiveSegmentClass)}
                       >
                         剧集
                       </button>
@@ -613,10 +626,10 @@ export default function MediaPage() {
                     variants={itemAnim}
                   >
                     <div
-                      className="group cursor-pointer premium-card p-0 h-full flex flex-col hover:ring-2 ring-primary/40"
+                      className="group cursor-pointer premium-card h-full overflow-hidden p-0 flex flex-col hover:ring-2 ring-primary/40"
                       onClick={() => handleSelectMedia(media)}
                     >
-                      <div className="aspect-[2/3] relative rounded-t-[2rem] overflow-hidden bg-muted">
+                      <div className="aspect-[2/3] relative overflow-hidden bg-muted">
                         {media.poster ? (
                           <Image
                             src={media.poster}

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -558,7 +558,7 @@ class ApiClient {
 
   // Media
   async searchMedia(query: string, source = "all", signal?: AbortSignal) {
-    return this.request<{ results: MediaItem[] }>(
+    return this.request<{ results: MediaItem[]; total?: number; warnings?: Record<string, string> }>(
       `/media/search?q=${encodeURIComponent(query)}&source=${source}`,
       { signal }
     );
@@ -1475,7 +1475,17 @@ class ApiClient {
         target: string;
         success: boolean;
         error: string | null;
+        username?: string;
+        bot_id?: number;
+        title?: string;
+        bot_status?: string;
       }>;
+      runtime?: {
+        polling?: boolean;
+        last_ok_at?: number | null;
+        last_error_at?: number | null;
+        last_error?: string;
+      };
     }>("/system/admin/bot/test", {
       method: "POST",
       body: JSON.stringify(target ? { target } : {}),
@@ -1603,6 +1613,13 @@ class ApiClient {
       '/system/admin/server-icon/upload',
       formData,
       'POST'
+    );
+  }
+
+  async terminateSchedulerJob(jobId: string) {
+    return this.request<{ job_id: string; terminated: boolean }>(
+      `/admin/scheduler/jobs/${encodeURIComponent(jobId)}/terminate`,
+      { method: "POST" },
     );
   }
 
@@ -1987,6 +2004,10 @@ export interface SystemInfo {
   telegram_bot?: {
     username: string | null;
     url: string | null;
+    enabled?: boolean;
+    configured?: boolean;
+    ok?: boolean;
+    error?: string;
   };
   telegram_links?: {
     groups: Array<{ label: string; url: string }>;

--- a/webui/src/store/system.ts
+++ b/webui/src/store/system.ts
@@ -4,14 +4,14 @@ import { api, type SystemInfo } from "@/lib/api";
 interface SystemStore {
   info: SystemInfo | null;
   loaded: boolean;
-  fetchInfo: () => Promise<void>;
+  fetchInfo: (force?: boolean) => Promise<void>;
 }
 
 export const useSystemStore = create<SystemStore>((set, get) => ({
   info: null,
   loaded: false,
-  fetchInfo: async () => {
-    if (get().loaded) return;
+  fetchInfo: async (force = false) => {
+    if (get().loaded && !force) return;
     try {
       const res = await api.getSystemInfo();
       if (res.success && res.data) {


### PR DESCRIPTION
Add robust Bangumi endpoint handling (bangumiEndpoint helper, v0 path, query params, nsfw filter) and tests; surface remote error details in HTTP JSON client responses. Return per-source errors from searchMedia and show warnings in UI. Improve Telegram runtime reporting and error caching, adjust public bot info, make bot test exercise getMe/getChat/getChatMember and expose runtime status in admin UI. Implement scheduler run lifecycle: startSchedulerRun/terminate, track running jobs, terminate API and UI button, propagate context cancellation throughout runner, and record finished runs with proper status/messages. Misc: reduce server icon cache TTL and add cache-busting URL, add hidden admin config docs to production config, minor UI style tweaks and test additions.