### PR TITLE
Telegram inline panels & scheduler enhancements

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -61,6 +61,8 @@ type App struct {
 	telegramLastErrorAt   int64
 	telegramLastError     string
 	telegramPolling       bool
+	telegramPanelMu       sync.Mutex
+	telegramPanels        map[string]telegramPanelContext
 	embyAdminMu           sync.Mutex
 	embyAdminCache        map[string]embyAdminCacheEntry
 }
@@ -92,6 +94,7 @@ func New(cfg config.Config, st *store.Store) (*App, error) {
 		sessions:       newSessionStore(cfg.SessionTTL, redisClient),
 		limiter:        newRateLimiter(redisClient),
 		redis:          redisClient,
+		telegramPanels: map[string]telegramPanelContext{},
 		embyAdminCache: map[string]embyAdminCacheEntry{},
 	}
 	app.configSignature = configFileSignature(cfg.ConfigFile)

--- a/internal/api/app_test.go
+++ b/internal/api/app_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"log/slog"
@@ -761,6 +763,136 @@ func TestTelegramEndpointAcceptsCommonBaseURLs(t *testing.T) {
 		if got := app.telegramEndpoint("getMe"); got != want {
 			t.Fatalf("telegramEndpoint(%q) = %q, want %q", base, got, want)
 		}
+	}
+}
+
+func TestTelegramErrorRedactsBotToken(t *testing.T) {
+	app := newTestApp(t)
+	app.cfg.TelegramBotToken = "123:SECRET"
+	raw := `Post "https://api.telegram.org/bot123:SECRET/getUpdates": context deadline exceeded 123:SECRET`
+	got := app.telegramSanitizeError(errors.New(raw))
+	if strings.Contains(got, "123:SECRET") || !strings.Contains(got, "/bot<redacted>/getUpdates") {
+		t.Fatalf("telegram error was not redacted: %s", got)
+	}
+	app.setTelegramRuntimeStatus(true, errors.New(raw))
+	status := app.telegramRuntimeStatus()
+	if strings.Contains(asString(status["last_error"]), "123:SECRET") {
+		t.Fatalf("runtime status leaked token: %#v", status)
+	}
+}
+
+func TestTelegramGetUpdatesAllowsCallbacks(t *testing.T) {
+	app := newTestApp(t)
+	app.cfg.TelegramMode = true
+	app.cfg.TelegramBotToken = "123:ABC"
+	var body map[string]any
+	tg := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/bot123:ABC/getUpdates" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"result":[]}`))
+	}))
+	defer tg.Close()
+	app.cfg.TelegramAPIURL = tg.URL
+	if _, err := app.telegramGetUpdates(context.Background(), 42); err != nil {
+		t.Fatal(err)
+	}
+	updates, _ := body["allowed_updates"].([]any)
+	foundCallback := false
+	for _, update := range updates {
+		if update == "callback_query" {
+			foundCallback = true
+		}
+	}
+	if !foundCallback || numeric(body["timeout"]) != 30 || numeric(body["offset"]) != 42 {
+		t.Fatalf("unexpected getUpdates body: %#v", body)
+	}
+}
+
+func TestTelegramAnonymousGroupUserRequiresInlineAuth(t *testing.T) {
+	app := newTestApp(t)
+	app.cfg.TelegramMode = true
+	app.cfg.TelegramBotToken = "123:ABC"
+	user := store.User{UID: 1001, Username: "target", Role: store.RoleNormal, Active: true, TelegramID: 888, CreatedAt: time.Now().Unix(), RegisterTime: time.Now().Unix()}
+	if _, err := app.store.CreateUser(user); err != nil {
+		t.Fatal(err)
+	}
+	requests := []map[string]any{}
+	tg := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		body["_path"] = r.URL.Path
+		requests = append(requests, body)
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":9001}}`))
+	}))
+	defer tg.Close()
+	app.cfg.TelegramAPIURL = tg.URL
+
+	app.handleTelegramUpdate(context.Background(), map[string]any{
+		"message": map[string]any{
+			"message_id": 77,
+			"text":       "/twguser target",
+			"chat":       map[string]any{"id": -1001, "type": "supergroup"},
+			"from":       map[string]any{"id": 1087968824, "is_bot": true},
+			"sender_chat": map[string]any{
+				"id": -1001,
+			},
+		},
+	})
+	if len(requests) != 1 {
+		t.Fatalf("expected one Telegram request, got %#v", requests)
+	}
+	if requests[0]["_path"] != "/bot123:ABC/sendMessage" {
+		t.Fatalf("expected sendMessage, got %#v", requests[0])
+	}
+	markup, _ := requests[0]["reply_markup"].(map[string]any)
+	keyboard, _ := markup["inline_keyboard"].([]any)
+	if len(keyboard) == 0 || !strings.Contains(asString(requests[0]["text"]), "验证") {
+		t.Fatalf("anonymous command did not create auth panel: %#v", requests[0])
+	}
+}
+
+func TestSchedulerManualRunUpdatesSingleHistoryEntry(t *testing.T) {
+	app := newTestApp(t)
+	run, okRun := app.startManualSchedulerJob(context.Background(), "daily_stats", nil)
+	if !okRun {
+		t.Fatal("manual scheduler job did not start")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for app.schedulerJobRunning("daily_stats") && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if app.schedulerJobRunning("daily_stats") {
+		t.Fatal("manual scheduler job did not finish")
+	}
+	runs := app.store.SchedulerRuns("daily_stats", 10)
+	if len(runs) != 1 {
+		t.Fatalf("manual run should update one history entry, got %d: %#v", len(runs), runs)
+	}
+	if runs[0].ID != run.ID || runs[0].Status != "success" || runs[0].Type != "manual" || runs[0].FinishedAt == 0 {
+		t.Fatalf("unexpected manual run history: %#v", runs[0])
+	}
+}
+
+func TestSchedulerManualTriggerSpecDisablesAutoRun(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/scheduler/jobs/daily_stats/schedule", strings.NewReader(`{"type":"manual"}`))
+	rr := httptest.NewRecorder()
+	app.handleSchedulerSchedule(rr, req, Params{"job_id": "daily_stats"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("schedule manual status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	spec := app.schedulerTriggerSpec("daily_stats")
+	if asString(spec["type"]) != "manual" || !schedulerTriggerDisabled(spec) {
+		t.Fatalf("manual trigger spec not persisted: %#v", spec)
+	}
+	if next := app.schedulerNextRunAt("daily_stats", spec, time.Now()); next != 0 {
+		t.Fatalf("manual trigger should not have next run, got %d", next)
 	}
 }
 

--- a/internal/api/http_json_client.go
+++ b/internal/api/http_json_client.go
@@ -23,6 +23,10 @@ func getJSON(ctx context.Context, endpoint string, headers map[string]string, ds
 }
 
 func postJSON(ctx context.Context, endpoint string, headers map[string]string, body any, dst any) error {
+	return postJSONWithTimeout(ctx, endpoint, headers, body, dst, 10*time.Second)
+}
+
+func postJSONWithTimeout(ctx context.Context, endpoint string, headers map[string]string, body any, dst any, timeout time.Duration) error {
 	data, _ := json.Marshal(body)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
 	if err != nil {
@@ -32,11 +36,18 @@ func postJSON(ctx context.Context, endpoint string, headers map[string]string, b
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
-	return doJSONRequest(req, dst)
+	return doJSONRequestWithTimeout(req, dst, timeout)
 }
 
 func doJSONRequest(req *http.Request, dst any) error {
-	client := &http.Client{Timeout: 10 * time.Second}
+	return doJSONRequestWithTimeout(req, dst, 10*time.Second)
+}
+
+func doJSONRequestWithTimeout(req *http.Request, dst any, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/internal/api/scheduler_daemon.go
+++ b/internal/api/scheduler_daemon.go
@@ -60,12 +60,14 @@ func schedulerJobEnabledByConfig(systemUpdateEnabled bool, job map[string]any) b
 }
 
 func (a *App) schedulerJobDue(jobID string, spec map[string]any, now time.Time) bool {
-	runs := a.store.SchedulerRuns(jobID, 1)
+	runs := a.store.SchedulerRuns(jobID, 20)
 	last := int64(0)
-	if len(runs) > 0 {
-		last = runs[0].StartedAt
-		if runs[0].Status == "running" && time.Since(time.Unix(runs[0].StartedAt, 0)) < 30*time.Minute {
+	for _, run := range runs {
+		if run.Status == "running" && time.Since(time.Unix(run.StartedAt, 0)) < 30*time.Minute {
 			return false
+		}
+		if run.Type == "auto" && run.StartedAt > last {
+			last = run.StartedAt
 		}
 	}
 	switch strings.ToLower(asString(spec["type"])) {
@@ -90,16 +92,48 @@ func (a *App) runScheduledJob(ctx context.Context, jobID string) {
 	defer finish()
 	started := time.Now().Unix()
 	run := store.SchedulerRun{JobID: jobID, Type: "auto", Trigger: "scheduler", Status: "running", Message: "running", StartedAt: started}
-	_ = a.store.AddSchedulerRun(run)
+	run, _ = a.store.AddSchedulerRunReturning(run)
 	req, _ := http.NewRequestWithContext(runCtx, http.MethodPost, "/scheduler/internal", nil)
 	summary, logs, err := a.runSchedulerJob(req, jobID)
-	run = schedulerFinishedRun(jobID, "auto", "scheduler", started, summary, logs, err)
-	_ = a.store.AddSchedulerRun(run)
+	finished := schedulerFinishedRun(jobID, "auto", "scheduler", started, summary, logs, err)
+	finished.ID = run.ID
+	_, _ = a.store.UpdateSchedulerRun(run.ID, func(run *store.SchedulerRun) error {
+		*run = finished
+		return nil
+	})
 	if err != nil {
 		slog.Warn("scheduler job failed", "job_id", jobID, "error", err)
 	} else {
 		slog.Info("scheduler job completed", "job_id", jobID)
 	}
+}
+
+func (a *App) startManualSchedulerJob(ctx context.Context, jobID string, params map[string]any) (store.SchedulerRun, bool) {
+	runCtx, finish, ok := a.startSchedulerRun(ctx, jobID)
+	if !ok {
+		return store.SchedulerRun{}, false
+	}
+	started := time.Now().Unix()
+	run, _ := a.store.AddSchedulerRunReturning(store.SchedulerRun{JobID: jobID, Type: "manual", Trigger: "manual", Status: "running", Message: "running", StartedAt: started})
+	go func() {
+		defer finish()
+		req, _ := http.NewRequestWithContext(runCtx, http.MethodPost, "/scheduler/manual", nil)
+		req = req.WithContext(context.WithValue(req.Context(), schedulerParamsContextKey, params))
+		req = req.WithContext(context.WithValue(req.Context(), schedulerManualContextKey, true))
+		summary, logs, err := a.runSchedulerJob(req, jobID)
+		finished := schedulerFinishedRun(jobID, "manual", "manual", started, summary, logs, err)
+		finished.ID = run.ID
+		_, _ = a.store.UpdateSchedulerRun(run.ID, func(current *store.SchedulerRun) error {
+			*current = finished
+			return nil
+		})
+		if err != nil {
+			slog.Warn("manual scheduler job failed", "job_id", jobID, "error", err)
+		} else {
+			slog.Info("manual scheduler job completed", "job_id", jobID)
+		}
+	}()
+	return run, true
 }
 
 func schedulerFinishedRun(jobID, runType, trigger string, started int64, summary map[string]any, logs []string, err error) store.SchedulerRun {
@@ -136,6 +170,42 @@ func (a *App) schedulerTriggerSpec(jobID string) map[string]any {
 		return schedule.TriggerSpec
 	}
 	return a.schedulerDefaultTriggerSpec(jobID)
+}
+
+func schedulerTriggerDisabled(spec map[string]any) bool {
+	return strings.EqualFold(asString(spec["type"]), "manual")
+}
+
+func (a *App) schedulerNextRunAt(jobID string, spec map[string]any, now time.Time) int64 {
+	if schedulerTriggerDisabled(spec) {
+		return 0
+	}
+	last := int64(0)
+	if runs := a.store.SchedulerRuns(jobID, 20); len(runs) > 0 {
+		for _, run := range runs {
+			if run.Type == "auto" && run.StartedAt > last {
+				last = run.StartedAt
+			}
+		}
+	}
+	switch strings.ToLower(asString(spec["type"])) {
+	case "cron_daily", "daily":
+		hour := clamp(int(numeric(spec["hour"])), 0, 23)
+		minute := clamp(int(numeric(spec["minute"])), 0, 59)
+		due := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
+		if !now.Before(due) || last >= due.Unix() {
+			due = due.Add(24 * time.Hour)
+		}
+		return due.Unix()
+	case "interval":
+		seconds := clamp(int(numeric(spec["seconds"])), 60, 604800)
+		if last == 0 {
+			return now.Unix()
+		}
+		return time.Unix(last+int64(seconds), 0).Unix()
+	default:
+		return 0
+	}
 }
 
 func (a *App) schedulerDefaultTriggerSpec(jobID string) map[string]any {

--- a/internal/api/scheduler_handlers.go
+++ b/internal/api/scheduler_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"time"
 )
 
 var schedulerJobs = []map[string]any{
@@ -25,17 +26,32 @@ func (a *App) handleSchedulerJobs(w http.ResponseWriter, r *http.Request, _ Para
 	for _, job := range schedulerJobs {
 		item := cloneMap(job)
 		jobID := fmt.Sprint(job["id"])
+		var spec map[string]any
 		if schedule, okSchedule := a.store.SchedulerSchedule(jobID); okSchedule {
-			item["trigger_spec"] = schedule.TriggerSpec
+			spec = schedule.TriggerSpec
 			item["is_custom"] = schedule.IsCustom
 		} else {
-			item["trigger_spec"] = a.schedulerDefaultTriggerSpec(jobID)
+			spec = a.schedulerDefaultTriggerSpec(jobID)
 			item["is_custom"] = false
 		}
+		item["trigger_spec"] = spec
 		item["default_trigger_spec"] = a.schedulerDefaultTriggerSpec(jobID)
 		item["last_run"] = nil
-		if runs := a.store.SchedulerRuns(jobID, 1); len(runs) > 0 {
+		item["next_run_at"] = zeroNil(a.schedulerNextRunAt(jobID, spec, time.Now()))
+		item["auto_disabled"] = schedulerTriggerDisabled(spec)
+		if runs := a.store.SchedulerRuns(jobID, 20); len(runs) > 0 {
 			item["last_run"] = runs[0]
+			var lastAuto, lastManual int64
+			for _, run := range runs {
+				if run.Type == "auto" && lastAuto == 0 {
+					lastAuto = run.StartedAt
+				}
+				if run.Type == "manual" && lastManual == 0 {
+					lastManual = run.StartedAt
+				}
+			}
+			item["last_auto_run_at"] = zeroNil(lastAuto)
+			item["last_manual_run_at"] = zeroNil(lastManual)
 		}
 		item["is_running"] = a.schedulerJobRunning(jobID)
 		jobs = append(jobs, item)
@@ -64,7 +80,7 @@ func (a *App) handleSchedulerLastRun(w http.ResponseWriter, r *http.Request, par
 	ok(w, "OK", map[string]any{"job_id": params["job_id"], "last_run": last})
 }
 func (a *App) handleSchedulerHistory(w http.ResponseWriter, r *http.Request, params Params) {
-	runs := a.store.SchedulerRuns(params["job_id"], 20)
+	runs := a.store.SchedulerRuns(params["job_id"], queryInt(r, "limit", 20))
 	ok(w, "OK", map[string]any{"job_id": params["job_id"], "history": runs, "total": len(runs)})
 }
 func (a *App) handleSchedulerSchedule(w http.ResponseWriter, r *http.Request, params Params) {
@@ -83,7 +99,9 @@ func (a *App) handleSchedulerSchedule(w http.ResponseWriter, r *http.Request, pa
 	}
 	payload := decodeMap(r)
 	spec := map[string]any{"type": firstNonEmpty(stringValue(payload, "type"), "interval")}
-	if spec["type"] == "cron_daily" {
+	if spec["type"] == "manual" {
+		spec = map[string]any{"type": "manual"}
+	} else if spec["type"] == "cron_daily" {
 		spec["hour"] = clamp(intValue(payload, "hour", 0), 0, 23)
 		spec["minute"] = clamp(intValue(payload, "minute", 0), 0, 59)
 	} else {

--- a/internal/api/scheduler_runner.go
+++ b/internal/api/scheduler_runner.go
@@ -47,20 +47,17 @@ func (a *App) sendExpiryReminders(ctx context.Context, days int) map[string]any 
 }
 
 func (a *App) handleSchedulerRunV2(w http.ResponseWriter, r *http.Request, params Params) {
-	now := time.Now().Unix()
 	jobID := params["job_id"]
-	runCtx, finish, okRun := a.startSchedulerRun(r.Context(), jobID)
+	if !schedulerJobExists(jobID) {
+		fail(w, http.StatusNotFound, "job not found")
+		return
+	}
+	run, okRun := a.startManualSchedulerJob(context.Background(), jobID, schedulerRequestParams(r))
 	if !okRun {
 		fail(w, http.StatusConflict, "job is already running")
 		return
 	}
-	defer finish()
-	_ = a.store.AddSchedulerRun(store.SchedulerRun{JobID: jobID, Type: "manual", Trigger: "manual", Status: "running", Message: "running", StartedAt: now})
-	req := r.WithContext(runCtx)
-	summary, logs, err := a.runSchedulerJob(req, jobID)
-	run := schedulerFinishedRun(jobID, "manual", "manual", now, summary, logs, err)
-	_ = a.store.AddSchedulerRun(run)
-	ok(w, "job executed", map[string]any{"job_id": run.JobID, "last_run": run})
+	ok(w, "job started", map[string]any{"job_id": run.JobID, "last_run": run})
 }
 
 func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []string, error) {
@@ -350,7 +347,7 @@ func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []
 		result["success"] = true
 		return result, []string{fmt.Sprintf("scanned %d upload files, deleted %d", int(numeric(result["scanned"])), int(numeric(result["deleted"])))}, nil
 	case "system_auto_update":
-		if !a.cfg.SystemUpdateEnabled {
+		if !a.cfg.SystemUpdateEnabled && !schedulerManualRun(r) {
 			return map[string]any{"success": true, "skipped": true, "enabled": false}, []string{"system auto update disabled"}, nil
 		}
 		result := applyGitUpdate(r.Context(), a.cfg.SystemUpdateRepoURL, a.cfg.SystemUpdateBranch, a.cfg.SystemUpdateRestartServices, false, false)
@@ -364,11 +361,25 @@ func (a *App) runSchedulerJob(r *http.Request, jobID string) (map[string]any, []
 }
 
 func schedulerRequestParams(r *http.Request) map[string]any {
+	if params, ok := r.Context().Value(schedulerParamsContextKey).(map[string]any); ok {
+		return params
+	}
 	payload := decodeMap(r)
 	if params, ok := payload["params"].(map[string]any); ok {
 		return params
 	}
 	return payload
+}
+
+type schedulerParamsKey struct{}
+type schedulerManualKey struct{}
+
+var schedulerParamsContextKey schedulerParamsKey
+var schedulerManualContextKey schedulerManualKey
+
+func schedulerManualRun(r *http.Request) bool {
+	manual, _ := r.Context().Value(schedulerManualContextKey).(bool)
+	return manual
 }
 
 func jobParamInt(params map[string]any, key string, fallback int) int {

--- a/internal/api/telegram.go
+++ b/internal/api/telegram.go
@@ -39,7 +39,7 @@ func (a *App) setTelegramRuntimeStatus(polling bool, err error) {
 	defer a.telegramStatusMu.Unlock()
 	a.telegramPolling = polling
 	if err != nil {
-		a.telegramLastError = err.Error()
+		a.telegramLastError = a.telegramSanitizeError(err)
 		a.telegramLastErrorAt = time.Now().Unix()
 		return
 	}
@@ -59,12 +59,16 @@ func (a *App) telegramRuntimeStatus() map[string]any {
 }
 
 func (a *App) telegramPost(ctx context.Context, method string, body map[string]any, dst any) error {
+	return a.telegramPostWithTimeout(ctx, method, body, dst, 20*time.Second)
+}
+
+func (a *App) telegramPostWithTimeout(ctx context.Context, method string, body map[string]any, dst any, timeout time.Duration) error {
 	if !a.telegramAvailable() {
 		return fmt.Errorf("Telegram is not enabled or bot token is not configured")
 	}
 	var payload telegramResponse
-	if err := postJSON(ctx, a.telegramEndpoint(method), map[string]string{"Accept": "application/json"}, body, &payload); err != nil {
-		return err
+	if err := postJSONWithTimeout(ctx, a.telegramEndpoint(method), map[string]string{"Accept": "application/json"}, body, &payload, timeout); err != nil {
+		return fmt.Errorf("%s", a.telegramSanitizeError(err))
 	}
 	if !payload.OK {
 		msg := strings.TrimSpace(payload.Description)
@@ -84,6 +88,20 @@ func (a *App) telegramPost(ctx context.Context, method string, body map[string]a
 	return nil
 }
 
+func (a *App) telegramSanitizeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	token := strings.TrimSpace(a.cfg.TelegramBotToken)
+	if token == "" {
+		return msg
+	}
+	msg = strings.ReplaceAll(msg, "/bot"+token, "/bot<redacted>")
+	msg = strings.ReplaceAll(msg, token, "<redacted>")
+	return msg
+}
+
 func (a *App) telegramGetMe(ctx context.Context) (map[string]any, error) {
 	var result map[string]any
 	err := a.telegramPost(ctx, "getMe", map[string]any{}, &result)
@@ -91,14 +109,57 @@ func (a *App) telegramGetMe(ctx context.Context) (map[string]any, error) {
 }
 
 func (a *App) telegramSendMessage(ctx context.Context, chatID any, text string) error {
+	_, err := a.telegramSendMessageWithMarkup(ctx, chatID, text, nil)
+	return err
+}
+
+func (a *App) telegramSendMessageWithMarkup(ctx context.Context, chatID any, text string, replyMarkup any) (int64, error) {
+	text = truncateString(strings.TrimSpace(text), 3900)
+	if text == "" {
+		return 0, fmt.Errorf("message text is empty")
+	}
+	body := map[string]any{
+		"chat_id":                  chatID,
+		"text":                     text,
+		"disable_web_page_preview": true,
+	}
+	if replyMarkup != nil {
+		body["reply_markup"] = replyMarkup
+	}
+	var result map[string]any
+	if err := a.telegramPost(ctx, "sendMessage", body, &result); err != nil {
+		return 0, err
+	}
+	return numeric(result["message_id"]), nil
+}
+
+func (a *App) telegramEditMessageText(ctx context.Context, chatID, messageID int64, text string, replyMarkup any) error {
 	text = truncateString(strings.TrimSpace(text), 3900)
 	if text == "" {
 		return fmt.Errorf("message text is empty")
 	}
-	return a.telegramPost(ctx, "sendMessage", map[string]any{
-		"chat_id":                  chatID,
-		"text":                     text,
-		"disable_web_page_preview": true,
+	body := map[string]any{"chat_id": chatID, "message_id": messageID, "text": text, "disable_web_page_preview": true}
+	if replyMarkup != nil {
+		body["reply_markup"] = replyMarkup
+	}
+	return a.telegramPost(ctx, "editMessageText", body, nil)
+}
+
+func (a *App) telegramDeleteMessage(ctx context.Context, chatID, messageID int64) error {
+	if chatID == 0 || messageID == 0 {
+		return nil
+	}
+	return a.telegramPost(ctx, "deleteMessage", map[string]any{"chat_id": chatID, "message_id": messageID}, nil)
+}
+
+func (a *App) telegramAnswerCallbackQuery(ctx context.Context, callbackID, text string, showAlert bool) error {
+	if strings.TrimSpace(callbackID) == "" {
+		return nil
+	}
+	return a.telegramPost(ctx, "answerCallbackQuery", map[string]any{
+		"callback_query_id": callbackID,
+		"text":              truncateString(text, 190),
+		"show_alert":        showAlert,
 	}, nil)
 }
 

--- a/internal/api/telegram_bot.go
+++ b/internal/api/telegram_bot.go
@@ -75,16 +75,20 @@ func (a *App) RunTelegramBot(ctx context.Context) error {
 
 func (a *App) telegramGetUpdates(ctx context.Context, offset int64) ([]map[string]any, error) {
 	var result []map[string]any
-	body := map[string]any{"timeout": 30, "allowed_updates": []string{"message", "chat_member", "my_chat_member"}}
+	body := map[string]any{"timeout": 30, "allowed_updates": []string{"message", "callback_query", "chat_member", "my_chat_member"}}
 	if offset > 0 {
 		body["offset"] = offset
 	}
-	err := a.telegramPost(ctx, "getUpdates", body, &result)
+	err := a.telegramPostWithTimeout(ctx, "getUpdates", body, &result, 45*time.Second)
 	return result, err
 }
 
 func (a *App) handleTelegramUpdate(ctx context.Context, update map[string]any) {
 	a.observeTelegramRoster(update)
+	if callback, _ := update["callback_query"].(map[string]any); callback != nil {
+		a.telegramHandleCallback(ctx, callback)
+		return
+	}
 	message, _ := update["message"].(map[string]any)
 	if message == nil {
 		return
@@ -429,35 +433,22 @@ func (a *App) telegramHandleFind(ctx context.Context, chatID, telegramID int64, 
 }
 
 func (a *App) telegramHandleGroupUser(ctx context.Context, chatID, telegramID int64, fields []string, message map[string]any) {
+	messageID := numeric(message["message_id"])
+	anonymousCommand := telegramIsAnonymousGroupMessage(message)
+	if anonymousCommand {
+		a.telegramSendGroupAdminAuth(ctx, chatID, messageID, fields, message)
+		return
+	}
 	if !a.telegramAdminID(telegramID) {
-		_ = a.telegramSendMessage(ctx, chatID, "没有管理员权限。")
+		a.telegramSendUnauthorizedAndCleanup(ctx, chatID, messageID)
 		return
 	}
-	query := strings.Join(fields[1:], " ")
-	if strings.TrimSpace(query) == "" {
-		if reply, _ := message["reply_to_message"].(map[string]any); reply != nil {
-			if from, _ := reply["from"].(map[string]any); from != nil {
-				if id := numeric(from["id"]); id != 0 {
-					if u, okUser := a.store.FindUserByTelegramID(id); okUser {
-						_ = a.telegramSendMessage(ctx, chatID, "群组用户查询\n\n"+telegramUserSummary(u))
-						return
-					}
-				}
-			}
-		}
-		_ = a.telegramSendMessage(ctx, chatID, "请回复目标用户消息后发送 /twguser，或发送 /twguser <用户名/UID/关键词>。")
+	user, reason := a.telegramResolveGroupUserTarget(fields, message)
+	if reason != "" {
+		_ = a.telegramSendMessage(ctx, chatID, reason)
 		return
 	}
-	users := a.telegramFindUsers(query, 6)
-	if len(users) == 0 {
-		_ = a.telegramSendMessage(ctx, chatID, "未找到匹配用户。")
-		return
-	}
-	if len(users) > 1 {
-		_ = a.telegramSendMessage(ctx, chatID, "找到多个匹配项，请缩小关键词。\n\n"+telegramUserList(users))
-		return
-	}
-	_ = a.telegramSendMessage(ctx, chatID, "群组用户查询\n\n"+telegramUserSummary(users[0]))
+	a.telegramSendGroupUserPanel(ctx, chatID, messageID, user, false)
 }
 
 func (a *App) telegramAdminID(telegramID int64) bool {
@@ -525,7 +516,7 @@ func (a *App) telegramGroupPrompt() string {
 	if text := strings.TrimSpace(a.cfg.TelegramBotGroupStartText); text != "" {
 		return a.telegramRenderText(text)
 	}
-	return "为避免泄露账号信息，请私聊 Bot 使用 /bind、/me、/emby 等账号命令。管理员可在群内使用 /twguser 进行只读查询。"
+	return "为避免泄露账号信息，请私聊 Bot 使用 /bind、/me、/emby 等账号命令。管理员可在群内使用 /twguser 打开用户管理面板。"
 }
 
 func (a *App) telegramBindPrompt() string {
@@ -569,7 +560,7 @@ func (a *App) telegramAdminHelpText() string {
 	if text := strings.TrimSpace(a.cfg.TelegramBotAdminHelpText); text != "" {
 		return a.telegramRenderText(text)
 	}
-	return "管理员帮助\n\n/stats 服务统计\n/userinfo <用户名/UID/关键词> 查看用户详情\n/twfind <用户名/UID/关键词> 搜索用户\n/twguser <关键词> 群组只读查询\n/twguser 回复群成员消息时按 Telegram 绑定关系查询\n\nBot 管理命令只展示非敏感摘要；用户写入、删除、封禁、密码和系统更新请在 Web 后台完成。"
+	return "管理员帮助\n\n/stats 服务统计\n/userinfo <用户名/UID/关键词> 查看用户详情\n/twfind <用户名/UID/关键词> 搜索用户\n/twguser <关键词> 群组用户管理面板\n/twguser 回复群成员消息时按 Telegram 绑定关系查询\n\n群组匿名管理员使用 /twguser 时需要通过 inline 按钮验证身份；每次按钮操作都会重新鉴权。"
 }
 
 func (a *App) telegramAboutText() string {

--- a/internal/api/telegram_inline.go
+++ b/internal/api/telegram_inline.go
@@ -1,0 +1,418 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/prejudice-studio/twilight/internal/store"
+)
+
+const telegramPanelTTL = time.Minute
+
+type telegramPanelContext struct {
+	Token            string
+	ChatID           int64
+	MessageID        int64
+	CommandMessageID int64
+	TargetUID        int64
+	Query            string
+	ReplyTelegramID  int64
+	ExpiresAt        int64
+	ConfirmAction    string
+}
+
+func telegramIsAnonymousGroupMessage(message map[string]any) bool {
+	if message == nil {
+		return false
+	}
+	if senderChat, _ := message["sender_chat"].(map[string]any); senderChat != nil {
+		return true
+	}
+	chat, _ := message["chat"].(map[string]any)
+	from, _ := message["from"].(map[string]any)
+	return numeric(chat["id"]) != 0 && !strings.EqualFold(asString(chat["type"]), "private") && numeric(from["id"]) == 0
+}
+
+func (a *App) telegramResolveGroupUserTarget(fields []string, message map[string]any) (store.User, string) {
+	return a.telegramResolveGroupUserTargetValues(telegramCommandQuery(fields), telegramReplyTelegramID(message))
+}
+
+func (a *App) telegramResolveGroupUserTargetValues(query string, replyTelegramID int64) (store.User, string) {
+	if strings.TrimSpace(query) == "" {
+		if replyTelegramID != 0 {
+			if u, okUser := a.store.FindUserByTelegramID(replyTelegramID); okUser {
+				return u, ""
+			}
+			return store.User{}, "目标 Telegram 尚未绑定 Twilight 账号。"
+		}
+		return store.User{}, "请回复目标用户消息后发送 /twguser，或发送 /twguser <用户名/UID/关键词>。"
+	}
+	users := a.telegramFindUsers(query, 6)
+	if len(users) == 0 {
+		return store.User{}, "未找到匹配用户。"
+	}
+	if len(users) > 1 {
+		return store.User{}, "找到多个匹配项，请缩小关键词。\n\n" + telegramUserList(users)
+	}
+	return users[0], ""
+}
+
+func (a *App) telegramSendGroupAdminAuth(ctx context.Context, chatID, commandMessageID int64, fields []string, message map[string]any) {
+	panel := a.telegramCreateAuthPanel(chatID, commandMessageID, telegramCommandQuery(fields), telegramReplyTelegramID(message))
+	markup := telegramInlineKeyboard([][]telegramInlineButton{{
+		{Text: "验证管理员身份", Data: "gadm:auth:" + panel.Token},
+	}})
+	messageID, err := a.telegramSendMessageWithMarkup(ctx, chatID, "匿名管理员指令需要先验证真实 Telegram 身份。", markup)
+	if err != nil {
+		return
+	}
+	panel.MessageID = messageID
+	a.telegramSavePanel(panel)
+}
+
+func (a *App) telegramSendGroupUserPanel(ctx context.Context, chatID, commandMessageID int64, target store.User, requireAuth bool) {
+	panel := a.telegramCreatePanel(chatID, commandMessageID, target)
+	text := a.telegramGroupUserPanelText(target)
+	markup := a.telegramGroupUserPanelMarkup(panel.Token, target, false)
+	messageID, err := a.telegramSendMessageWithMarkup(ctx, chatID, text, markup)
+	if err != nil {
+		return
+	}
+	panel.MessageID = messageID
+	if requireAuth {
+		panel.ConfirmAction = "auth"
+	}
+	a.telegramSavePanel(panel)
+}
+
+func (a *App) telegramCreatePanel(chatID, commandMessageID int64, target store.User) telegramPanelContext {
+	token := telegramRandomToken()
+	return telegramPanelContext{
+		Token:            token,
+		ChatID:           chatID,
+		CommandMessageID: commandMessageID,
+		TargetUID:        target.UID,
+		ExpiresAt:        time.Now().Add(telegramPanelTTL).Unix(),
+	}
+}
+
+func (a *App) telegramCreateAuthPanel(chatID, commandMessageID int64, query string, replyTelegramID int64) telegramPanelContext {
+	token := telegramRandomToken()
+	return telegramPanelContext{
+		Token:            token,
+		ChatID:           chatID,
+		CommandMessageID: commandMessageID,
+		Query:            strings.TrimSpace(query),
+		ReplyTelegramID:  replyTelegramID,
+		ExpiresAt:        time.Now().Add(telegramPanelTTL).Unix(),
+	}
+}
+
+func (a *App) telegramSavePanel(panel telegramPanelContext) {
+	a.telegramPanelMu.Lock()
+	if a.telegramPanels == nil {
+		a.telegramPanels = map[string]telegramPanelContext{}
+	}
+	a.telegramPanels[panel.Token] = panel
+	a.telegramPanelMu.Unlock()
+	a.telegramSchedulePanelExpiry(panel.Token)
+}
+
+func (a *App) telegramSchedulePanelExpiry(token string) {
+	time.AfterFunc(telegramPanelTTL+time.Second, func() {
+		a.telegramPanelMu.Lock()
+		panel, ok := a.telegramPanels[token]
+		if !ok {
+			a.telegramPanelMu.Unlock()
+			return
+		}
+		delay := time.Until(time.Unix(panel.ExpiresAt, 0))
+		if delay > 0 {
+			a.telegramPanelMu.Unlock()
+			time.AfterFunc(delay+time.Second, func() { a.telegramExpirePanel(token) })
+			return
+		}
+		delete(a.telegramPanels, token)
+		a.telegramPanelMu.Unlock()
+		_ = a.telegramDeleteMessage(context.Background(), panel.ChatID, panel.MessageID)
+	})
+}
+
+func (a *App) telegramExpirePanel(token string) {
+	a.telegramPanelMu.Lock()
+	panel, ok := a.telegramPanels[token]
+	if !ok || panel.ExpiresAt > time.Now().Unix() {
+		a.telegramPanelMu.Unlock()
+		if ok {
+			a.telegramSchedulePanelExpiry(token)
+		}
+		return
+	}
+	delete(a.telegramPanels, token)
+	a.telegramPanelMu.Unlock()
+	_ = a.telegramDeleteMessage(context.Background(), panel.ChatID, panel.MessageID)
+}
+
+func (a *App) telegramPanel(token string) (telegramPanelContext, bool) {
+	a.telegramPanelMu.Lock()
+	defer a.telegramPanelMu.Unlock()
+	panel, ok := a.telegramPanels[token]
+	if !ok || panel.ExpiresAt < time.Now().Unix() {
+		if ok {
+			delete(a.telegramPanels, token)
+		}
+		return telegramPanelContext{}, false
+	}
+	return panel, true
+}
+
+func (a *App) telegramTouchPanel(panel telegramPanelContext) telegramPanelContext {
+	panel.ExpiresAt = time.Now().Add(telegramPanelTTL).Unix()
+	a.telegramPanelMu.Lock()
+	a.telegramPanels[panel.Token] = panel
+	a.telegramPanelMu.Unlock()
+	a.telegramSchedulePanelExpiry(panel.Token)
+	return panel
+}
+
+func (a *App) telegramDeletePanel(token string) {
+	a.telegramPanelMu.Lock()
+	delete(a.telegramPanels, token)
+	a.telegramPanelMu.Unlock()
+}
+
+func (a *App) telegramHandleCallback(ctx context.Context, callback map[string]any) {
+	data := asString(callback["data"])
+	parts := strings.Split(data, ":")
+	if len(parts) < 3 || parts[0] != "gadm" {
+		return
+	}
+	callbackID := asString(callback["id"])
+	from, _ := callback["from"].(map[string]any)
+	actorID := numeric(from["id"])
+	message, _ := callback["message"].(map[string]any)
+	chat, _ := message["chat"].(map[string]any)
+	chatID := numeric(chat["id"])
+	messageID := numeric(message["message_id"])
+	token := parts[len(parts)-1]
+	panel, ok := a.telegramPanel(token)
+	if !ok {
+		_ = a.telegramAnswerCallbackQuery(ctx, callbackID, "面板已过期，请重新发送 /twguser。", true)
+		_ = a.telegramDeleteMessage(ctx, chatID, messageID)
+		return
+	}
+	if panel.MessageID == 0 && messageID != 0 {
+		panel.MessageID = messageID
+	}
+	if panel.ChatID == 0 && chatID != 0 {
+		panel.ChatID = chatID
+	}
+	if !a.telegramAdminID(actorID) {
+		_ = a.telegramAnswerCallbackQuery(ctx, callbackID, "没有管理员权限。", true)
+		a.telegramSendUnauthorizedAndCleanup(ctx, panel.ChatID, panel.CommandMessageID)
+		return
+	}
+	if parts[1] == "auth" {
+		panel.ConfirmAction = ""
+		panel = a.telegramTouchPanel(panel)
+		_ = a.telegramAnswerCallbackQuery(ctx, callbackID, "身份验证通过。", false)
+		if panel.TargetUID == 0 {
+			target, reason := a.telegramResolveGroupUserTargetValues(panel.Query, panel.ReplyTelegramID)
+			if reason != "" {
+				_ = a.telegramEditMessageText(ctx, panel.ChatID, panel.MessageID, reason, nil)
+				a.telegramDeletePanel(panel.Token)
+				return
+			}
+			panel.TargetUID = target.UID
+			panel = a.telegramTouchPanel(panel)
+		}
+		a.telegramEditPanel(ctx, panel, false)
+		return
+	}
+	if len(parts) < 4 || parts[1] != "act" {
+		return
+	}
+	action := parts[2]
+	panel = a.telegramTouchPanel(panel)
+	_ = a.telegramAnswerCallbackQuery(ctx, callbackID, "操作处理中。", false)
+	a.telegramApplyPanelAction(ctx, panel, action)
+}
+
+func (a *App) telegramApplyPanelAction(ctx context.Context, panel telegramPanelContext, action string) {
+	target, ok := a.store.User(panel.TargetUID)
+	if !ok {
+		a.telegramDeletePanel(panel.Token)
+		_ = a.telegramEditMessageText(ctx, panel.ChatID, panel.MessageID, "目标用户不存在或已被删除。", nil)
+		return
+	}
+	switch action {
+	case "refresh":
+		panel.ConfirmAction = ""
+		a.telegramTouchPanel(panel)
+		a.telegramEditPanel(ctx, panel, false)
+	case "enable", "disable":
+		enabled := action == "enable"
+		if !enabled && a.telegramProtectedTarget(target) {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "管理员账号禁止通过 Telegram 面板禁用。")
+			return
+		}
+		updated, err := a.store.UpdateUser(target.UID, func(u *store.User) error { u.Active = enabled; return nil })
+		if err != nil {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "更新用户状态失败: "+err.Error())
+			return
+		}
+		if updated.EmbyID != "" && a.cfg.EmbyURL != "" {
+			_ = a.embySetUserEnabled(ctx, updated.EmbyID, a.embyShouldEnableUser(updated))
+		}
+		a.telegramEditPanelWithNotice(ctx, panel, updated, "用户状态已更新。")
+	case "delete":
+		if a.telegramProtectedTarget(target) {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "管理员账号禁止通过 Telegram 面板删除。")
+			return
+		}
+		panel.ConfirmAction = "delete"
+		panel = a.telegramTouchPanel(panel)
+		a.telegramEditPanel(ctx, panel, true)
+	case "delete_confirm":
+		if panel.ConfirmAction != "delete" {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "请先点击删除按钮确认风险。")
+			return
+		}
+		if a.telegramProtectedTarget(target) {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "管理员账号禁止通过 Telegram 面板删除。")
+			return
+		}
+		if err := a.store.DeleteUser(target.UID); err != nil {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "删除用户失败: "+err.Error())
+			return
+		}
+		a.sessions.DeleteUser(ctx, target.UID)
+		a.telegramDeletePanel(panel.Token)
+		_ = a.telegramEditMessageText(ctx, panel.ChatID, panel.MessageID, fmt.Sprintf("已删除用户 %s。", target.Username), nil)
+	case "kick", "ban":
+		if target.TelegramID == 0 {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "目标用户未绑定 Telegram，无法执行群组操作。")
+			return
+		}
+		if a.telegramProtectedTarget(target) {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "管理员账号禁止通过 Telegram 面板移出或封禁。")
+			return
+		}
+		var err error
+		if action == "kick" {
+			err = a.telegramKickChatMember(ctx, fmt.Sprint(panel.ChatID), target.TelegramID)
+		} else {
+			err = a.telegramBanChatMember(ctx, fmt.Sprint(panel.ChatID), target.TelegramID)
+		}
+		if err != nil {
+			a.telegramEditPanelWithNotice(ctx, panel, target, "Telegram 群组操作失败: "+a.telegramSanitizeError(err))
+			return
+		}
+		a.telegramEditPanelWithNotice(ctx, panel, target, "Telegram 群组操作已完成。")
+	default:
+		a.telegramEditPanelWithNotice(ctx, panel, target, "未知操作。")
+	}
+}
+
+func (a *App) telegramEditPanel(ctx context.Context, panel telegramPanelContext, confirmDelete bool) {
+	target, ok := a.store.User(panel.TargetUID)
+	if !ok {
+		_ = a.telegramEditMessageText(ctx, panel.ChatID, panel.MessageID, "目标用户不存在或已被删除。", nil)
+		return
+	}
+	_ = a.telegramEditMessageText(ctx, panel.ChatID, panel.MessageID, a.telegramGroupUserPanelText(target), a.telegramGroupUserPanelMarkup(panel.Token, target, confirmDelete))
+}
+
+func (a *App) telegramEditPanelWithNotice(ctx context.Context, panel telegramPanelContext, target store.User, notice string) {
+	panel.ConfirmAction = ""
+	panel = a.telegramTouchPanel(panel)
+	text := a.telegramGroupUserPanelText(target)
+	if strings.TrimSpace(notice) != "" {
+		text += "\n\n" + notice
+	}
+	_ = a.telegramEditMessageText(ctx, panel.ChatID, panel.MessageID, text, a.telegramGroupUserPanelMarkup(panel.Token, target, false))
+}
+
+func (a *App) telegramGroupUserPanelText(u store.User) string {
+	return "群组用户面板\n\n" + telegramUserSummary(u) + "\n\n面板 1 分钟无操作会自动删除。"
+}
+
+func (a *App) telegramGroupUserPanelMarkup(token string, u store.User, confirmDelete bool) any {
+	rows := [][]telegramInlineButton{{
+		{Text: "刷新", Data: "gadm:act:refresh:" + token},
+	}}
+	if u.Active {
+		rows = append(rows, []telegramInlineButton{{Text: "禁用账号", Data: "gadm:act:disable:" + token}})
+	} else {
+		rows = append(rows, []telegramInlineButton{{Text: "启用账号", Data: "gadm:act:enable:" + token}})
+	}
+	if confirmDelete {
+		rows = append(rows, []telegramInlineButton{{Text: "确认删除用户", Data: "gadm:act:delete_confirm:" + token}})
+	} else {
+		rows = append(rows, []telegramInlineButton{{Text: "删除用户", Data: "gadm:act:delete:" + token}})
+	}
+	if u.TelegramID != 0 {
+		rows = append(rows, []telegramInlineButton{
+			{Text: "移出群组", Data: "gadm:act:kick:" + token},
+			{Text: "封禁群组", Data: "gadm:act:ban:" + token},
+		})
+	}
+	return telegramInlineKeyboard(rows)
+}
+
+func (a *App) telegramProtectedTarget(u store.User) bool {
+	return u.Role == store.RoleAdmin || (u.TelegramID != 0 && a.telegramAdminID(u.TelegramID))
+}
+
+func (a *App) telegramSendUnauthorizedAndCleanup(ctx context.Context, chatID, sourceMessageID int64) {
+	warnID, _ := a.telegramSendMessageWithMarkup(ctx, chatID, "没有管理员权限。此提示和越权指令将在 30 秒后自动删除。", nil)
+	time.AfterFunc(30*time.Second, func() {
+		_ = a.telegramDeleteMessage(context.Background(), chatID, warnID)
+		_ = a.telegramDeleteMessage(context.Background(), chatID, sourceMessageID)
+	})
+}
+
+type telegramInlineButton struct {
+	Text string
+	Data string
+}
+
+func telegramInlineKeyboard(rows [][]telegramInlineButton) any {
+	keyboard := make([][]map[string]string, 0, len(rows))
+	for _, row := range rows {
+		items := make([]map[string]string, 0, len(row))
+		for _, button := range row {
+			items = append(items, map[string]string{"text": button.Text, "callback_data": button.Data})
+		}
+		keyboard = append(keyboard, items)
+	}
+	return map[string]any{"inline_keyboard": keyboard}
+}
+
+func telegramCommandQuery(fields []string) string {
+	if len(fields) <= 1 {
+		return ""
+	}
+	return strings.Join(fields[1:], " ")
+}
+
+func telegramReplyTelegramID(message map[string]any) int64 {
+	if reply, _ := message["reply_to_message"].(map[string]any); reply != nil {
+		if from, _ := reply["from"].(map[string]any); from != nil {
+			return numeric(from["id"])
+		}
+	}
+	return 0
+}
+
+func telegramRandomToken() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(buf)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1619,6 +1619,11 @@ func (s *Store) AddSignin(uid int64, points int) (Signin, bool, error) {
 }
 
 func (s *Store) AddSchedulerRun(run SchedulerRun) error {
+	_, err := s.AddSchedulerRunReturning(run)
+	return err
+}
+
+func (s *Store) AddSchedulerRunReturning(run SchedulerRun) (SchedulerRun, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if run.ID == 0 {
@@ -1638,7 +1643,30 @@ func (s *Store) AddSchedulerRun(run SchedulerRun) error {
 	if len(s.state.SchedulerRuns) > 200 {
 		s.state.SchedulerRuns = s.state.SchedulerRuns[:200]
 	}
-	return s.saveLocked()
+	return run, s.saveLocked()
+}
+
+func (s *Store) UpdateSchedulerRun(id int64, fn func(*SchedulerRun) error) (SchedulerRun, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id == 0 {
+		return SchedulerRun{}, ErrNotFound
+	}
+	for i := range s.state.SchedulerRuns {
+		if s.state.SchedulerRuns[i].ID != id {
+			continue
+		}
+		run := s.state.SchedulerRuns[i]
+		if err := fn(&run); err != nil {
+			return SchedulerRun{}, err
+		}
+		if run.FinishedAt == 0 && run.EndedAt != 0 {
+			run.FinishedAt = run.EndedAt
+		}
+		s.state.SchedulerRuns[i] = run
+		return run, s.saveLocked()
+	}
+	return SchedulerRun{}, ErrNotFound
 }
 
 func (s *Store) SchedulerRuns(jobID string, limit int) []SchedulerRun {

--- a/webui/src/app/(main)/admin/scheduler/page.tsx
+++ b/webui/src/app/(main)/admin/scheduler/page.tsx
@@ -194,7 +194,7 @@ function ScheduleEditor({ job, open, onOpenChange, onSaved }: ScheduleEditorProp
     if (!open || !job) return;
     const spec = job.trigger_spec;
     if (spec.type === "manual") {
-      setType("cron_daily");
+      setType("manual");
       setHour(0);
       setMinute(0);
       setIntervalValue(1);
@@ -227,7 +227,9 @@ function ScheduleEditor({ job, open, onOpenChange, onSaved }: ScheduleEditorProp
     setSaving(true);
     try {
       let payload: SchedulerTriggerSpec;
-      if (type === "cron_daily") {
+      if (type === "manual") {
+        payload = { type: "manual" };
+      } else if (type === "cron_daily") {
         if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
           toast({ title: "时间不合法", description: "小时 0-23 / 分钟 0-59", variant: "destructive" });
           return;
@@ -315,13 +317,18 @@ function ScheduleEditor({ job, open, onOpenChange, onSaved }: ScheduleEditorProp
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
+                <SelectItem value="manual">关闭自动执行，仅手动</SelectItem>
                 <SelectItem value="cron_daily">每日固定时间</SelectItem>
                 <SelectItem value="interval">固定间隔</SelectItem>
               </SelectContent>
             </Select>
           </div>
 
-          {type === "cron_daily" ? (
+          {type === "manual" ? (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-sm text-amber-700 dark:text-amber-300">
+              保存后该任务不会被调度器自动执行，管理员仍可点击“立即运行”手动触发。
+            </div>
+          ) : type === "cron_daily" ? (
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-2">
                 <Label>小时 (0-23)</Label>
@@ -374,7 +381,7 @@ function ScheduleEditor({ job, open, onOpenChange, onSaved }: ScheduleEditorProp
           )}
 
           <p className="text-xs text-muted-foreground">
-            修改后立即生效并落库，重启进程后仍保留。可点击「恢复默认」清除覆盖。
+            修改后立即生效并落库，重启进程后仍保留。选择“关闭自动执行”可完全停止该任务的自动调度；可点击「恢复默认」清除覆盖。
           </p>
 
           {job.id === "cleanup_no_emby" && (
@@ -514,7 +521,7 @@ export default function AdminSchedulerPage() {
   );
 
   const schedulerHasTimedJobs = useMemo(
-    () => jobs.some((j) => !j.manual_only && j.enabled),
+    () => jobs.some((j) => !j.manual_only && j.enabled && j.trigger_spec?.type !== "manual"),
     [jobs]
   );
 

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -2691,6 +2691,7 @@ export interface SchedulerJobItem {
   trigger_spec: SchedulerTriggerSpec;
   default_trigger_spec: SchedulerTriggerSpec;
   is_custom: boolean;
+  auto_disabled?: boolean;
   last_auto_run_at?: number | null;
   last_manual_run_at?: number | null;
   persisted_info?: Record<string, unknown> | null;


### PR DESCRIPTION
Add interactive Telegram inline admin panels and related helpers, plus scheduler and HTTP client improvements. Introduces telegram_inline.go to manage short-lived inline panels, callback handling, auth flow, and panel actions (enable/disable/delete/kick/ban). Sanitize Telegram errors and extend telegram API calls (timeouts, allowed updates, send/edit/delete message helpers). Scheduler: add manual run API/path, persist/update scheduler runs (AddSchedulerRunReturning, UpdateSchedulerRun), compute next run times, disable auto-run when type is manual, and improve run concurrency checks. Add tests for Telegram behavior and manual scheduler runs, and update web UI/types to support manual trigger type and show auto-disabled state.