### PR TITLE
fix:修复配置编辑器里 Telegram 群组/频道 ID 被转成数字导致科学计数法的形式写入配置文件的问题。

### DIFF
--- a/webui/src/app/(main)/admin/config/page.tsx
+++ b/webui/src/app/(main)/admin/config/page.tsx
@@ -94,7 +94,7 @@ const NUMERIC_LIST_FIELD_KEYS = new Set([
   "streak_bonus_points",
 ]);
 
-const MIXED_ID_LIST_FIELD_KEYS = new Set([
+const STRING_ID_LIST_FIELD_KEYS = new Set([
   "admin_id",
   "group_id",
   "channel_id",
@@ -121,8 +121,8 @@ function serializeListValue(
     .map((v) => v.trim())
     .filter((v) => v.length > 0);
 
-  if (MIXED_ID_LIST_FIELD_KEYS.has(fieldKey)) {
-    return items.map((v) => (/^-?\d+$/.test(v) ? Number.parseInt(v, 10) : v));
+  if (STRING_ID_LIST_FIELD_KEYS.has(fieldKey)) {
+    return items;
   }
 
   const originalLooksNumeric =


### PR DESCRIPTION
<img width="938" height="460" alt="7d194f14-52b1-4693-abb7-382437dd4aa1" src="https://github.com/user-attachments/assets/bc18a5d1-b358-44be-80f1-0658cca26bb1" />
